### PR TITLE
fixed tests code cannot convert ".." to type rune

### DIFF
--- a/apiapp.go
+++ b/apiapp.go
@@ -40,11 +40,11 @@ In the appname folder has the follow struct:
 	├── routers
 	│   └── router.go
 	├── tests
-	│   └── default_test.go		
+	│   └── default_test.go
 	├── main.go
 	└── models
-	    └── object.go            
-	    └── user.go            
+	    └── object.go
+	    └── user.go
 
 `,
 }
@@ -471,14 +471,14 @@ import (
 	"runtime"
 	"path/filepath"
 	_ "{{.Appname}}/routers"
-		
+
 	"github.com/astaxie/beego"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func init() {
 	_, file, _, _ := runtime.Caller(1)
-	apppath, _ := filepath.Abs(filepath.Dir(filepath.Join(file, ".." + filepath.Separator)))
+	apppath, _ := filepath.Abs(filepath.Dir(filepath.Join(file, ".." + string(filepath.Separator))))
 	beego.TestBeegoInit(apppath)
 }
 
@@ -487,9 +487,9 @@ func TestGet(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/object", nil)
 	w := httptest.NewRecorder()
 	beego.BeeApp.Handlers.ServeHTTP(w, r)
-	
+
 	beego.Trace("testing", "TestGet", "Code[%d]\n%s", w.Code, w.Body.String())
-	
+
 	Convey("Subject: Test Station Endpoint\n", t, func() {
 	        Convey("Status Code Should Be 200", func() {
 	                So(w.Code, ShouldEqual, 200)

--- a/new.go
+++ b/new.go
@@ -38,15 +38,15 @@ The [appname] folder has following structure:
          |- default.go
     |- models
     |- routers
-         |- router.go	
+         |- router.go
     |- tests
          |- default_test.go
 	|- static
          |- js
          |- css
-         |- img             
+         |- img
     |- views
-        index.tpl                   
+        index.tpl
 
 `,
 }
@@ -179,14 +179,14 @@ import (
 	"runtime"
 	"path/filepath"
 	_ "{{.Appname}}/routers"
-		
+
 	"github.com/astaxie/beego"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func init() {
 	_, file, _, _ := runtime.Caller(1)
-	apppath, _ := filepath.Abs(filepath.Dir(filepath.Join(file, ".." + filepath.Separator)))
+	apppath, _ := filepath.Abs(filepath.Dir(filepath.Join(file, ".." + string(filepath.Separator))))
 	beego.TestBeegoInit(apppath)
 }
 
@@ -196,9 +196,9 @@ func TestMain(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	beego.BeeApp.Handlers.ServeHTTP(w, r)
-	
+
 	beego.Trace("testing", "TestMain", "Code[%d]\n%s", w.Code, w.Body.String())
-	
+
 	Convey("Subject: Test Station Endpoint\n", t, func() {
 	        Convey("Status Code Should Be 200", func() {
 	                So(w.Code, ShouldEqual, 200)
@@ -234,7 +234,7 @@ var indextpl = `<!DOCTYPE html>
   	<head>
     	<title>Beego</title>
     	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-	
+
 		<style type="text/css">
 			body {
 				margin: 0px;
@@ -290,7 +290,7 @@ var indextpl = `<!DOCTYPE html>
 			}
 		</style>
 	</head>
-  	
+
   	<body>
   		<header class="hero-unit" style="background-color:#A9F16C">
 			<div class="container">


### PR DESCRIPTION
修正在使用bee生成的测试用例代码时，文件路径没有转换为字符串导致报错的问题
