### PR TITLE
[Bug Fix] Added os.O_EXCL flag to make sure existing files are NOT overwritten

### DIFF
--- a/g_models.go
+++ b/g_models.go
@@ -749,7 +749,6 @@ import (
 
 func init() {
 	ns := beego.NewNamespace("/v1",
-		/*
 		beego.NSNamespace("/object",
 			beego.NSInclude(
 				&controllers.ObjectController{},
@@ -760,7 +759,6 @@ func init() {
 				&controllers.UserController{},
 			),
 		),
-*/
 		{{nameSpaces}}
 	)
 	beego.AddNamespace(ns)


### PR DESCRIPTION
the current version will open existing file and possibly truncate it, O_EXCL will make sure that if the file already exists, do nothing with it.
