### PR TITLE
Drop json "omitempty" tag from field name in swagger

### DIFF
--- a/g_docs.go
+++ b/g_docs.go
@@ -568,7 +568,8 @@ func getModel(str string) (pkgpath, objectname string, m swagger.Model, realType
 							if field.Tag != nil {
 								stag := reflect.StructTag(strings.Trim(field.Tag.Value, "`"))
 								if tag := stag.Get("json"); tag != "" {
-									name = tag
+									leaveomitempty := strings.Split(tag, ",")
+									name = leaveomitempty[0]
 								}
 								if thrifttag := stag.Get("thrift"); thrifttag != "" {
 									ts := strings.Split(thrifttag, ",")


### PR DESCRIPTION
This change prevents the omitempty json struct tag from appearing in the swagger documentation. 

So for a struct like `json:"deviceName,omitempty", only deviceName is taken as the name.