### PR TITLE
fix gitignore for golang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+#Custom
 .DS_Store
 bee
-*.exe
 *.exe~


### PR DESCRIPTION
Update gitignore to use a better one for Golang
https://github.com/github/gitignore/blob/master/Go.gitignore
