### PR TITLE
修改生成文档时，@Success 第三个参数解析错误的问题

### DIFF
--- a/g_docs.go
+++ b/g_docs.go
@@ -395,10 +395,13 @@ func parserComments(comments *ast.CommentGroup, funcName, controllerName, pkgpat
 							tmp = make([]rune, 0)
 							j += 1
 							start = false
-							continue
-						} else {
-							st[j] = strings.TrimSpace(ss[i+1:])
-							break
+							if j == 1 {
+								continue
+							} else {
+								st[j] = strings.TrimSpace(ss[i+1:])
+								break
+
+							}
 						}
 					} else {
 						start = true


### PR DESCRIPTION
原来的代码，当第三个参数有多个空格时，比如
// @Success 200 {string} delete success!
第三个参数会解析成success!，即会忽略第一个空格前的单词，修改后，可以正常解析。