### PR TITLE
Fix bug that execute the cmd not in application catalog

### DIFF
--- a/g_appcode.go
+++ b/g_appcode.go
@@ -985,6 +985,12 @@ func getPackagePath(curpath string) (packpath string) {
 		ColorLog("[ERRO] Can't generate application code outside of GOPATH '%s'\n", gopath)
 		os.Exit(2)
 	}
+	
+	if curpath == appsrcpath {
+		ColorLog("[ERRO] Can't generate application code outside of application PATH \n")
+		os.Exit(2)
+	}
+	
 	packpath = strings.Join(strings.Split(curpath[len(appsrcpath)+1:], string(filepath.Separator)), "/")
 	return
 }


### PR DESCRIPTION
2015/12/31 10:02:34 [INFO] Using matching model 'Post'
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
main.getPackagePath(0xc082005b60, 0xf, 0x0, 0x0)
E:/ossbuild/src/bee/g_appcode.go:988 +0x5f7
main.generateController(0xc0820022b0, 0x4, 0xc082005b60, 0xf)
E:/ossbuild/src/bee/g_controllers.go:52 +0xadc
main.generateScaffold(0xc0820022b0, 0x4, 0xc0821150c0, 0x16,
0xc082005b60, 0xf,
0xc082118040, 0x5, 0xc0821150e0, 0x1e)
E:/ossbuild/src/bee/g_scaffold.go:18 +0x2d7
main.generateCode(0xc0de40, 0xc08200c1b0, 0x3, 0x3, 0x0)
E:/ossbuild/src/bee/g.go:123 +0x16c9
main.main()
E:/ossbuild/src/bee/bee.go:114 +0x37d