### PR TITLE
目录需要做一次EvalSymlinks操作。

### DIFF
--- a/apiapp.go
+++ b/apiapp.go
@@ -643,7 +643,8 @@ func checkEnv(appname string) (apppath, packpath string, err error) {
 	if err != nil {
 		return
 	}
-
+        curpath, _ = path.EvalSymlinks(curpath)
+        
 	gopath := os.Getenv("GOPATH")
 	Debugf("gopath:%s", gopath)
 	if gopath == "" {

--- a/g_appcode.go
+++ b/g_appcode.go
@@ -965,6 +965,7 @@ func getFileName(tbName string) (filename string) {
 }
 
 func getPackagePath(curpath string) (packpath string) {
+        curpath, _ = filepath.EvalSymlinks(curpath)
 	gopath := os.Getenv("GOPATH")
 	Debugf("gopath:%s", gopath)
 	if gopath == "" {


### PR DESCRIPTION
如果传入参数curpath是一个link的目录，gopath一般与curpath有部分是相同的根目录，但函数内部只对gopath进行EvalSymlinks，这样就导致两个目录完全不相同，最终会导致haspath为false，出错退出程序。
此问题涉及到两个文件：g_appcode.go，apiapp.go