### PR TITLE
Generate gocs support go buildin type in comment param

### DIFF
--- a/g_docs.go
+++ b/g_docs.go
@@ -430,7 +430,7 @@ func parserComments(comments *ast.CommentGroup, funcName, controllerName, pkgpat
 						typeFormat := strings.Split(sType, ":")
 						para.Type = typeFormat[0]
 						para.Format = typeFormat[1]
-					}else {
+					} else {
 						fmt.Fprintf(os.Stderr, "[%s.%s] Unknow param type: %s\n", controllerName, funcName, typ)
 					}
 				}

--- a/g_docs.go
+++ b/g_docs.go
@@ -426,6 +426,12 @@ func parserComments(comments *ast.CommentGroup, funcName, controllerName, pkgpat
 					if typ == "string" || typ == "number" || typ == "integer" || typ == "boolean" ||
 						typ == "array" || typ == "file" {
 						para.Type = typ
+					} else if sType, ok := basicTypes[typ]; ok {
+						typeFormat := strings.Split(sType, ":")
+						para.Type = typeFormat[0]
+						para.Format = typeFormat[1]
+					}else {
+						fmt.Fprintf(os.Stderr, "[%s.%s] Unknow param type: %s\n", controllerName, funcName, typ)
 					}
 				}
 				if len(p) > 4 {


### PR DESCRIPTION
`generate gocs` 自动将注释参数中的 golang 原生类型转换成对应的 swagger 类型