### PR TITLE
Update g_docs.go

### DIFF
--- a/g_docs.go
+++ b/g_docs.go
@@ -413,7 +413,7 @@ func parserComments(comments *ast.CommentGroup, funcName, controllerName, pkgpat
 				pp := strings.Split(p[2], ".")
 				typ := pp[len(pp)-1]
 				if len(pp) >= 2 {
-					cmpath, m, mod, realTypes := getModel(typ)
+					cmpath, m, mod, realTypes := getModel(p[2])
 					para.Schema = &swagger.Schema{
 						Ref: "#/definitions/" + m,
 					}


### PR DESCRIPTION
@PARAM in connecting models, I keep getting "can not find the object", but file /models/Template.go is exists
// @Param   body     body   models.Template    true       "Templates body"

Only you pass the model name, but do not pass the location.
Although getModel() function again trying to split ( strs := strings.Split(str, ".") ) the parameter to the location and name.