### PR TITLE
Update g_appcode.go

### DIFF
--- a/g_appcode.go
+++ b/g_appcode.go
@@ -983,6 +983,14 @@ func getPackagePath(curpath string) (packpath string) {
 	wgopath := filepath.SplitList(gopath)
 
 	for _, wg := range wgopath {
+		//Maybe is a path
+		if filepath.HasPrefix(strings.ToLower(curpath), strings.ToLower(wg)) {
+			haspath = true
+			appsrcpath = wg
+			break
+		}
+		
+		//Maybe is a symlink
 		wg, _ = filepath.EvalSymlinks(path.Join(wg, "src"))
 
 		if filepath.HasPrefix(strings.ToLower(curpath), strings.ToLower(wg)) {


### PR DESCRIPTION
If use symlink to define GOPATH, bee generate won't work .

Example:

``` shell
ln -s /mnt/go/ /go/
export GOPATH=/go

cd /go/src
bee api hello_api
cd /go/src/hello_api
bee generate appcode -driver=mysql -level=1 -conn='xxx@xxx'
> [ERRO] Can't generate application code outside of GOPATH '/go'
```

In g_appcode.go(line 985), using a EvalSymlinks, and got wg = "/mnt/go", but curpath = "/go/src/hello_api" now, that causing the bug.

When using "bee" tool in GOPATH but echo "code is outside of GOPATH"