### PR TITLE
Fix incorrect generation of postgres table id type

### DIFF
--- a/g_migration.go
+++ b/g_migration.go
@@ -129,7 +129,7 @@ func (m postgresqlDriver) generateSQLFromFields(fields string) string {
 			return ""
 		}
 		if i == 0 && strings.ToLower(kv[0]) != "id" {
-			sql += "id interger serial primary key,"
+			sql += "id serial primary key,"
 		}
 		sql += snakeString(kv[0]) + " " + typ + ","
 		if tag != "" {


### PR DESCRIPTION
Found on (PostgreSQL) 9.5.4 on Mac OS X El Capitan. As serial is `autoincrementing integer`, adding `interger`, which seems to misspelled, before it, causes that migration cannot be run without manual changeing this line.