### PR TITLE
Fix GoVersion value

### DIFF
--- a/banner.go
+++ b/banner.go
@@ -57,7 +57,7 @@ func show(out io.Writer, content string) {
 	}
 
 	err = t.Execute(out, vars{
-		runtime.Version(),
+		getGoVersion(),
 		runtime.GOOS,
 		runtime.GOARCH,
 		runtime.NumCPU(),

--- a/version.go
+++ b/version.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	path "path/filepath"
 	"regexp"
+	"strings"
 )
 
 var cmdVersion = &Command{
@@ -113,4 +115,17 @@ func getBeegoVersion() string {
 
 	}
 	return "Beego not installed. Please install it first: https://github.com/astaxie/beego"
+}
+
+func getGoVersion() string {
+	var (
+		cmdOut []byte
+		err    error
+	)
+
+	if cmdOut, err = exec.Command("go", "version").Output(); err != nil {
+		fmt.Fprintln(os.Stderr, "There was an error running go version command:", err)
+		os.Exit(2)
+	}
+	return strings.Split(string(cmdOut), " ")[2]
 }


### PR DESCRIPTION
Fix for #295: Use `exec.Command(cmd)` to get Go version dynamically, instead of using `runtime.Version()`.