### PR TITLE
修复代码顺序搞反导致的开源协议展现错误

### DIFF
--- a/g_docs.go
+++ b/g_docs.go
@@ -70,6 +70,7 @@ func generateDocs(curpath string) {
 	}
 
 	rootapi.Infos = swagger.Information{}
+	rootapi.Infos.License = &swagger.License{}
 	rootapi.SwaggerVersion = "2.0"
 	//analysis API comments
 	if f.Comments != nil {
@@ -89,18 +90,10 @@ func generateDocs(curpath string) {
 					rootapi.Infos.Contact.Name = strings.TrimSpace(s[len("@Name"):])
 				} else if strings.HasPrefix(s, "@URL") {
 					rootapi.Infos.Contact.URL = strings.TrimSpace(s[len("@URL"):])
-				} else if strings.HasPrefix(s, "@License") {
-					if rootapi.Infos.License == nil {
-						rootapi.Infos.License = &swagger.License{Name: strings.TrimSpace(s[len("@License"):])}
-					} else {
-						rootapi.Infos.License.Name = strings.TrimSpace(s[len("@License"):])
-					}
 				} else if strings.HasPrefix(s, "@LicenseUrl") {
-					if rootapi.Infos.License == nil {
-						rootapi.Infos.License = &swagger.License{URL: strings.TrimSpace(s[len("@LicenseUrl"):])}
-					} else {
-						rootapi.Infos.License.URL = strings.TrimSpace(s[len("@LicenseUrl"):])
-					}
+					rootapi.Infos.License.URL = strings.TrimSpace(s[len("@LicenseUrl"):])
+				} else if strings.HasPrefix(s, "@License") {
+				    rootapi.Infos.License.Name = strings.TrimSpace(s[len("@License"):])
 				} else if strings.HasPrefix(s, "@Schemes") {
 					rootapi.Schemes = strings.Split(strings.TrimSpace(s[len("@Schemes"):]), ",")
 				} else if strings.HasPrefix(s, "@Host") {


### PR DESCRIPTION
具体表现：当`@License`和`@LicenseUrl`在一块时
1.`@License`在前`@LicenseUrl`在后时，协议名变成了 Url xxxx
2.`@LicenseUrl`在前`@License`在后时，协议名正常，但链接指向有误（指向本地）