### PR TITLE
Swagger: parse @LicenseUrl first

### DIFF
--- a/g_docs.go
+++ b/g_docs.go
@@ -145,17 +145,17 @@ func generateDocs(curpath string) {
 					rootapi.Infos.Contact.Name = strings.TrimSpace(s[len("@Name"):])
 				} else if strings.HasPrefix(s, "@URL") {
 					rootapi.Infos.Contact.URL = strings.TrimSpace(s[len("@URL"):])
-				} else if strings.HasPrefix(s, "@License") {
-					if rootapi.Infos.License == nil {
-						rootapi.Infos.License = &swagger.License{Name: strings.TrimSpace(s[len("@License"):])}
-					} else {
-						rootapi.Infos.License.Name = strings.TrimSpace(s[len("@License"):])
-					}
 				} else if strings.HasPrefix(s, "@LicenseUrl") {
 					if rootapi.Infos.License == nil {
-						rootapi.Infos.License = &swagger.License{URL: strings.TrimSpace(s[len("@LicenseUrl"):])}
+					        rootapi.Infos.License = &swagger.License{URL: strings.TrimSpace(s[len("@LicenseUrl"):])}
 					} else {
-						rootapi.Infos.License.URL = strings.TrimSpace(s[len("@LicenseUrl"):])
+					        rootapi.Infos.License.URL = strings.TrimSpace(s[len("@LicenseUrl"):])
+					}
+				} else if strings.HasPrefix(s, "@License") {
+					if rootapi.Infos.License == nil {
+					        rootapi.Infos.License = &swagger.License{Name: strings.TrimSpace(s[len("@License"):])}
+					} else {
+						rootapi.Infos.License.Name = strings.TrimSpace(s[len("@License"):])
 					}
 				} else if strings.HasPrefix(s, "@Schemes") {
 					rootapi.Schemes = strings.Split(strings.TrimSpace(s[len("@Schemes"):]), ",")


### PR DESCRIPTION
`@LicenseUrl` should be parsed first
```
strings.HasPrefix(s, "@License")
```
This code will also match `@LicenseUrl`, so we should parse `@LicenseUrl` first.