### PR TITLE
Fixes debug log message

### DIFF
--- a/apiapp.go
+++ b/apiapp.go
@@ -558,8 +558,7 @@ func createapi(cmd *Command, args []string) int {
 
 	apppath, packpath, err := checkEnv(args[0])
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(2)
+		logger.Fatalf("%s", err)
 	}
 	if driver == "" {
 		driver = "mysql"

--- a/apiapp.go
+++ b/apiapp.go
@@ -658,7 +658,7 @@ func checkEnv(appname string) (apppath, packpath string, err error) {
 	gopath := gps[0]
 
 	logger.Warn("You current workdir is not inside $GOPATH/src")
-	logger.Debugf("GOPATH: %s", gopath)
+	logger.Debugf("GOPATH: %s", __FILE__(), __LINE__(), gopath)
 
 	gosrcpath := path.Join(gopath, "src")
 	apppath = path.Join(gosrcpath, appname)

--- a/bee.go
+++ b/bee.go
@@ -90,6 +90,8 @@ var commands = []*Command{
 	cmdFix,
 }
 
+var logger = GetBeeLogger(os.Stdout)
+
 func main() {
 	flag.Usage = usage
 	flag.Parse()

--- a/g.go
+++ b/g.go
@@ -91,7 +91,7 @@ func generateCode(cmd *Command, args []string) int {
 
 	gopath := gps[0]
 
-	logger.Debugf("GOPATH: %s", gopath)
+	logger.Debugf("GOPATH: %s", __FILE__(), __LINE__(), gopath)
 
 	gcmd := args[0]
 	switch gcmd {

--- a/g_appcode.go
+++ b/g_appcode.go
@@ -954,7 +954,7 @@ func getPackagePath(curpath string) (packpath string) {
 		logger.Fatal("GOPATH environment variable is not set or empty")
 	}
 
-	logger.Debugf("GOPATH: %s", gopath)
+	logger.Debugf("GOPATH: %s", __FILE__(), __LINE__(), gopath)
 
 	appsrcpath := ""
 	haspath := false

--- a/logger.go
+++ b/logger.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"text/template"
@@ -155,7 +154,7 @@ func (l *BeeLogger) mustLog(level int, message string, args ...interface{}) {
 
 // mustLogDebug logs a debug message only if debug mode
 // is enabled. i.e. DEBUG_ENABLED="1"
-func (l *BeeLogger) mustLogDebug(message string, args ...interface{}) {
+func (l *BeeLogger) mustLogDebug(message string, file string, line int, args ...interface{}) {
 	if !IsDebugEnabled() {
 		return
 	}
@@ -163,9 +162,7 @@ func (l *BeeLogger) mustLogDebug(message string, args ...interface{}) {
 	// Change the output to Stderr
 	l.SetOutput(os.Stderr)
 
-	// Create the log record and Get the filename
-	// and the line number of the caller
-	_, file, line, _ := runtime.Caller(1)
+	// Create the log record
 	record := LogRecord{
 		ID:       fmt.Sprintf("%04d", atomic.AddUint64(&sequenceNo, 1)),
 		Level:    l.getColorLevel(levelDebug),
@@ -178,13 +175,13 @@ func (l *BeeLogger) mustLogDebug(message string, args ...interface{}) {
 }
 
 // Debug outputs a debug log message
-func (l *BeeLogger) Debug(message string) {
-	l.mustLogDebug(message)
+func (l *BeeLogger) Debug(message string, file string, line int) {
+	l.mustLogDebug(message, file, line)
 }
 
 // Debugf outputs a formatted debug log message
-func (l *BeeLogger) Debugf(message string, vars ...interface{}) {
-	l.mustLogDebug(message, vars...)
+func (l *BeeLogger) Debugf(message string, file string, line int, vars ...interface{}) {
+	l.mustLogDebug(message, file, line, vars...)
 }
 
 // Info outputs an information log message

--- a/logger.go
+++ b/logger.go
@@ -39,7 +39,8 @@ const (
 
 var (
 	sequenceNo uint64
-	logger     *BeeLogger
+	instance   *BeeLogger
+	once       sync.Once
 )
 
 // BeeLogger logs logging records to the specified io.Writer
@@ -79,9 +80,15 @@ func init() {
 	MustCheck(err)
 	debugLogRecordTemplate, err = template.New("dbgLogRecordTemplate").Funcs(funcs).Parse(debugLogFormat)
 	MustCheck(err)
+}
 
-	// Initialize the logger instance with a NewColorWriter output
-	logger = &BeeLogger{output: NewColorWriter(os.Stdout)}
+// GetBeeLogger initializes the logger instance with a NewColorWriter output
+// and returns a singleton
+func GetBeeLogger(w io.Writer) *BeeLogger {
+	once.Do(func() {
+		instance = &BeeLogger{output: NewColorWriter(w)}
+	})
+	return instance
 }
 
 // SetOutput sets the logger output destination

--- a/logger.go
+++ b/logger.go
@@ -61,7 +61,6 @@ type LogRecord struct {
 var (
 	logRecordTemplate      *template.Template
 	debugLogRecordTemplate *template.Template
-	debugLogFormat         string
 )
 
 func init() {
@@ -141,6 +140,10 @@ func (l *BeeLogger) getColorLevel(level int) string {
 // mustLog logs the message according to the specified level and arguments.
 // It panics in case of an error.
 func (l *BeeLogger) mustLog(level int, message string, args ...interface{}) {
+	// Acquire the lock
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	// Create the logging record and pass into the output
 	record := LogRecord{
 		ID:      fmt.Sprintf("%04d", atomic.AddUint64(&sequenceNo, 1)),

--- a/migrate.go
+++ b/migrate.go
@@ -73,7 +73,7 @@ func runMigration(cmd *Command, args []string) int {
 
 	gopath := gps[0]
 
-	logger.Debugf("GOPATH: %s", gopath)
+	logger.Debugf("GOPATH: %s", __FILE__(), __LINE__(), gopath)
 
 	// Load the configuration
 	err := loadConfig()

--- a/run.go
+++ b/run.go
@@ -99,7 +99,7 @@ func runApp(cmd *Command, args []string) int {
 
 	logger.Infof("Using '%s' as 'appname'", appname)
 
-	logger.Debugf("Current path: %s", currpath)
+	logger.Debugf("Current path: %s", __FILE__(), __LINE__(), currpath)
 
 	if runmode == "prod" || runmode == "dev" {
 		os.Setenv("BEEGO_RUNMODE", runmode)

--- a/test.go
+++ b/test.go
@@ -56,7 +56,7 @@ func testApp(cmd *Command, args []string) int {
 
 	currpath, _ := os.Getwd()
 
-	logger.Debugf("Current path: %s", currpath)
+	logger.Debugf("Current path: %s", __FILE__(), __LINE__(), currpath)
 
 	err := loadConfig()
 	if err != nil {

--- a/util.go
+++ b/util.go
@@ -262,3 +262,15 @@ func IsDebugEnabled() bool {
 	debugMode := os.Getenv("DEBUG_ENABLED")
 	return map[string]bool{"1": true, "0": false}[debugMode]
 }
+
+// __FILE__ returns the file name in which the function was invoked
+func __FILE__() string {
+	_, file, _, _ := runtime.Caller(1)
+	return file
+}
+
+// __LINE__ returns the line number at which the function was invoked
+func __LINE__() int {
+	_, _, line, _ := runtime.Caller(1)
+	return line
+}

--- a/watch.go
+++ b/watch.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bytes"
-	"github.com/howeyc/fsnotify"
 	"os"
 	"os/exec"
 	"regexp"
@@ -24,6 +23,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/howeyc/fsnotify"
 )
 
 var (
@@ -209,7 +210,7 @@ func Kill() {
 
 // Restart kills the running command process and starts it again
 func Restart(appname string) {
-	logger.Debugf("Kill running process")
+	logger.Debugf("Kill running process", __FILE__(), __LINE__())
 	Kill()
 	go Start(appname)
 }


### PR DESCRIPTION
This fixes the debug log message which was constantly showing `logger.go:187` instead of showing the file name & lineNo of the actual caller.

Added also two functions: `__FILE__()` and `__LINE__()` that do the same thing as C++ macros `__LINE__` and `__FILE__`.