### PR TITLE
Removes the temp dir once bee pack is done 

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -495,6 +495,13 @@ func packApp(cmd *Command, args []string) int {
 	tmpdir := path.Join(os.TempDir(), "beePack-"+str)
 
 	os.Mkdir(tmpdir, 0700)
+	defer func() {
+		// Remove the tmpdir once bee pack is done
+		err := os.RemoveAll(tmpdir)
+		if err != nil {
+			logger.Error("Failed to remove the generated temp dir")
+		}
+	}()
 
 	if build {
 		logger.Info("Building application...")


### PR DESCRIPTION
This fixes #330 by removing the generated temp directory to avoid fulling the `/tmp` after running `bee pack` a few times.