### PR TITLE
Set the output format for bee version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 _obj
 _test
 .idea
+.vscode
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/banner.go
+++ b/banner.go
@@ -8,7 +8,8 @@ import (
 	"text/template"
 )
 
-type vars struct {
+// RuntimeInfo holds information about the current runtime.
+type RuntimeInfo struct {
 	GoVersion    string
 	GOOS         string
 	GOARCH       string
@@ -45,7 +46,7 @@ func show(out io.Writer, content string) {
 		logger.Fatalf("Cannot parse the banner template: %s", err)
 	}
 
-	err = t.Execute(out, vars{
+	err = t.Execute(out, RuntimeInfo{
 		getGoVersion(),
 		runtime.GOOS,
 		runtime.GOARCH,


### PR DESCRIPTION
This adds the ability to set the output format (using -o flag) of bee version command. It supports both JSON and YAML formats.