### PR TITLE
Handle case when appname argument is missing

### DIFF
--- a/hproseapp.go
+++ b/hproseapp.go
@@ -300,9 +300,8 @@ func init() {
 func createhprose(cmd *Command, args []string) int {
 	output := cmd.Out()
 
-	if len(args) < 1 {
-		ColorLog("[ERRO] Argument [appname] is missing\n")
-		os.Exit(2)
+	if len(args) != 1 {
+		logger.Fatal("Argument [appname] is missing")
 	}
 
 	curpath, _ := os.Getwd()


### PR DESCRIPTION
This fixes the latest breaking changes which make use of `ColorLog` as it no longer supported.