### PR TITLE
给bee run增加了一个参数ex，允许watch额外的包

### DIFF
--- a/run.go
+++ b/run.go
@@ -23,7 +23,7 @@ import (
 )
 
 var cmdRun = &Command{
-	UsageLine: "run [appname] [watchall] [-main=*.go] [-downdoc=true]  [-gendoc=true] [-vendor=true] [-e=folderToExclude] [-extra=extraPackageToWatch] [-tags=goBuildTags] [-runmode=BEEGO_RUNMODE]",
+	UsageLine: "run [appname] [watchall] [-main=*.go] [-downdoc=true]  [-gendoc=true] [-vendor=true] [-e=folderToExclude] [-ex=extraPackageToWatch] [-tags=goBuildTags] [-runmode=BEEGO_RUNMODE]",
 	Short:     "Run the application by starting a local development server",
 	Long: `
 Run command will supervise the filesystem of the application for any changes, and recompile/restart it.
@@ -65,7 +65,7 @@ func init() {
 	cmdRun.Flag.BoolVar(&vendorWatch, "vendor", false, "Enable watch vendor folder.")
 	cmdRun.Flag.StringVar(&buildTags, "tags", "", "Set the build tags. See: https://golang.org/pkg/go/build/")
 	cmdRun.Flag.StringVar(&runmode, "runmode", "", "Set the Beego run mode.")
-	cmdRun.Flag.Var(&extraPackages, "extra", "List of extra package to watch.")
+	cmdRun.Flag.Var(&extraPackages, "ex", "List of extra package to watch.")
 	exit = make(chan bool)
 }
 
@@ -129,9 +129,7 @@ func runApp(cmd *Command, args []string) int {
 		// get the full path
 		for _, packagePath := range extraPackages {
 			if found, _, _fullPath := SearchGOPATHs(packagePath); found {
-				logger.Warnf("%v", _fullPath)
 				readAppDirectories(_fullPath, &paths)
-				logger.Warnf("%v", paths)
 			} else {
 				logger.Warnf("No extra package '%s' found in your GOPATH", packagePath)
 			}


### PR DESCRIPTION
有时候项目需要同时维护多个包，现在的bee命令只能监控当前目录，所以设计增加了一个参数ex（sort for extra），允许用户自定义监控更多的包变化，例子如下：

```
bee run -ex github.com/szyhf/di-convert -ex github.com/szyhf/go-sproto
```

则除了当前目录的go文件发生变化外，di-convert和go-sproto包（递归）下的文件也会被监控。

你看看有没有兴趣，我觉得挺有用。