### PR TITLE
add scripts option(custom commands)

### DIFF
--- a/cmd/bee.go
+++ b/cmd/bee.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/beego/bee/cmd/commands/new"
 	_ "github.com/beego/bee/cmd/commands/pack"
 	_ "github.com/beego/bee/cmd/commands/run"
+	_ "github.com/beego/bee/cmd/commands/scripts"
 	_ "github.com/beego/bee/cmd/commands/version"
 	"github.com/beego/bee/utils"
 )

--- a/cmd/commands/scripts/scripts.go
+++ b/cmd/commands/scripts/scripts.go
@@ -1,0 +1,44 @@
+package scripts
+
+import (
+	"os/exec"
+
+	"os"
+
+	"runtime"
+
+	"strings"
+
+	"github.com/beego/bee/cmd/commands"
+	"github.com/beego/bee/cmd/commands/version"
+	"github.com/beego/bee/config"
+	"github.com/beego/bee/logger"
+)
+
+func init() {
+	for commandName, command := range config.Conf.Scripts {
+		CmdNew := &commands.Command{
+			UsageLine: commandName,
+			Short:     command,
+			PreRun:    func(cmd *commands.Command, args []string) { version.ShowShortVersionBanner() },
+			Run:       RunScript,
+		}
+		commands.AvailableCommands = append(commands.AvailableCommands, CmdNew)
+	}
+}
+
+func RunScript(cmd *commands.Command, args []string) int {
+	var c *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin", "linux":
+		c = exec.Command("sh", "-c", cmd.Short+" "+strings.Join(args, " "))
+	case "windows": //TODO
+	}
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	err := c.Run()
+	if err != nil {
+		beeLogger.Log.Error(err.Error())
+	}
+	return 0
+}

--- a/config/conf.go
+++ b/config/conf.go
@@ -79,8 +79,9 @@ var Conf struct {
 		Driver string
 		Conn   string
 	}
-	EnableReload       bool `json:"enable_reload" yaml:"enable_reload"`
-	EnableNotification bool `json:"enable_notification" yaml:"enable_notification"`
+	EnableReload       bool              `json:"enable_reload" yaml:"enable_reload"`
+	EnableNotification bool              `json:"enable_notification" yaml:"enable_notification"`
+	Scripts            map[string]string `json:"scripts" yaml:"scripts"`
 }
 
 func init() {


### PR DESCRIPTION
example to use:
1. Go test with custom params or other test framework like ginkgo
2. Fronted tools like grunt
3. Other custom  commands(build,deploy etc)

config in Beefile
like command name: command
```
scripts:
    test: APP_ENV=test APP_CONF_PATH=$(pwd)/conf go test  -v -cover  $(go list ./... | grep -v /vendor/)
```
This automatic add to commands
<img width="1117" alt="screen shot 2017-03-11 at 12 18 11" src="https://cloud.githubusercontent.com/assets/9318209/23822381/d35e1c50-0654-11e7-85d8-d6678b998015.png">

know issue not support windows(TODO), not test on linux

Thank for @BorisBorshevsky about idea:)


