### PR TITLE
Fixes desktop notificator for Windows and Linux

### DIFF
--- a/utils/notification.go
+++ b/utils/notification.go
@@ -1,3 +1,16 @@
+// Copyright 2017 bee authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
 package utils
 
 import (
@@ -21,9 +34,9 @@ func Notify(text, title string) {
 	case "darwin":
 		osxNotify(text, title)
 	case "linux":
-		windowsNotify(text, title)
-	case "windows":
 		linuxNotify(text, title)
+	case "windows":
+		windowsNotify(text, title)
 	}
 }
 
@@ -45,7 +58,7 @@ func windowsNotify(text, title string) {
 }
 
 func linuxNotify(text, title string) {
-	exec.Command("notify-send", "-i", "", title, text)
+	exec.Command("notify-send", "-i", "", title, text).Run()
 }
 
 func existTerminalNotifier() bool {


### PR DESCRIPTION
Fixes these bugs:
* `windowsNotify()` was called for `runtime.GOOS == "linux"`
* `linuxNotify()` does not work since `exec.Command(...).Run()` was not invoked.