### PR TITLE
fix docker build error by dockerBuildTemplate

### DIFF
--- a/cmd/commands/dockerize/dockerize.go
+++ b/cmd/commands/dockerize/dockerize.go
@@ -44,8 +44,7 @@ ENTRYPOINT $APP_DIR/{{.Entrypoint}}
 ADD . $APP_DIR
 
 # Compile the binary and statically link
-RUN cd $APP_DIR
-RUN CGO_ENABLED=0 godep go build -ldflags '-d -w -s'
+RUN cd $APP_DIR && CGO_ENABLED=0 godep go build -ldflags '-d -w -s'
 
 EXPOSE {{.Expose}}
 `


### PR DESCRIPTION
I found "bee dockerize" command bug.
This is a commit that fixed a bug in Dockerfile generated by the dockerize command.

When I used the dockerize command, the following error occurred in docker build.

```
$ bee dockerize
$ docker build .
Step 1 : FROM library/golang
 ---> 9ad50708c1cb
~~~~~~~~~~~~~~~~~~~~~~~~
Step 9 : RUN CGO_ENABLED=0 godep go build -ldflags '-d -w -s'
 ---> Running in cefd1fd7d91f
godep: [WARNING]: godep should only be used inside a valid go package directory and    
godep: [WARNING]: may not function correctly. You are probably outside of your $GOPATH.  
godep: [WARNING]:	Current Directory: /go  
godep: [WARNING]:	$GOPATH: /go  
godep: No Godeps found (or in any parent directory)  
````

This happens because the cd command and the godep command are written on separate lines in the Dockerfile generated by the dockerize command.
Therefore, in this commit, cd command and godep command are put together into one line.