### PR TITLE
Fix mistake of execution directory by dockerBuldTemplate

### DIFF
--- a/cmd/commands/dockerize/dockerize.go
+++ b/cmd/commands/dockerize/dockerize.go
@@ -40,7 +40,7 @@ ENV APP_DIR $GOPATH{{.Appdir}}
 RUN mkdir -p $APP_DIR
 
 # Set the entrypoint
-ENTRYPOINT $APP_DIR/{{.Entrypoint}}
+ENTRYPOINT (cd $APP_DIR && ./{{.Entrypoint}})
 ADD . $APP_DIR
 
 # Compile the binary and statically link


### PR DESCRIPTION
This is a commit that fixed a bug in Entrypoint of Dockerfile generated by the dockerize command.

Before the change, the directory to execute the program with entrypoint is as follows.

```
# cd /proc/5
# ls -l
...
lrwxrwxrwx 1 root root 0 Mar 20 13:49 cwd -> /go
...
lrwxrwxrwx 1 root root 0 Mar 20 13:47 exe -> /go/src/sample_app/sample_app
...
```

Therefore, for example, access to the static file is "404 not found".

After changing, problem was avoided by changing directory at entry point.

```
# cd /proc/5
# ls -l
...
lrwxrwxrwx 1 root root 0 Mar 20 13:50 cwd -> /go/src/sample_app
...
lrwxrwxrwx 1 root root 0 Mar 20 13:50 exe -> /go/src/sample_app/sample_app
...
```