### PR TITLE
Fixed an error in the basicType of pointer when the swagger document was automatically generated

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -881,7 +881,7 @@ func typeAnalyser(f *ast.Field) (isSlice bool, realType, swaggerType string) {
 		if k, ok := basicTypes[basicType]; ok {
 			return false, basicType, k
 		}
-		return false, fmt.Sprint(t.X), "object"
+		return false, basicType, "object"
 	case *ast.MapType:
 		val := fmt.Sprintf("%v", t.Value)
 		if isBasicType(val) {

--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -877,6 +877,10 @@ func typeAnalyser(f *ast.Field) (isSlice bool, realType, swaggerType string) {
 	}
 	switch t := f.Type.(type) {
 	case *ast.StarExpr:
+		basicType := fmt.Sprint(t.X)
+		if k, ok := basicTypes[basicType]; ok {
+			return false, basicType, k
+		}
 		return false, fmt.Sprint(t.X), "object"
 	case *ast.MapType:
 		val := fmt.Sprintf("%v", t.Value)


### PR DESCRIPTION
Fixed an error in the basicType of pointer when the swagger document was automatically generated
For example

```
type inputReg struct {
	Phone        string
	DepartmentID *uint32
}
// @Param _ body controllers.userCT.inputReg true
// @router /Reg/ [post]
func (this *UserController) Reg() {
}
```
Run 'bee generate docs':The DepartmentID will be generated

```
"DepartmentID": {
                    "$ref": "#/definitions/userCT.uint32"
                },
```
in swagger.json.
And Then swagger will report this error:

```
Resolver error at paths./User/Reg/.post.parameters.0.schema.properties.DepartmentID.$ref
Could not resolve reference because of: Could not resolve pointer: /definitions/userCT.uint32 does not exist in document
Resolver error at definitions.userCT.inputReg.properties.DepartmentID.$ref
Could not resolve reference because of: Could not resolve pointer: /definitions/userCT.uint32 does not
```