### PR TITLE
Added MySQL year data type

### DIFF
--- a/generate/g_appcode.go
+++ b/generate/g_appcode.go
@@ -101,6 +101,7 @@ var typeMappingMysql = map[string]string{
 	"decimal":            "float64",
 	"binary":             "string", // binary
 	"varbinary":          "string",
+	"year":               "int16",
 }
 
 // typeMappingPostgres maps SQL data type to corresponding Go data type


### PR DESCRIPTION
I was trying to create an API using MySQL sakila test database and I've noticed that the year data type was missing.