### PR TITLE
Fix: docs generator skips everything containing 'vendor'

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -104,7 +104,11 @@ func ParsePackagesFromDir(dirpath string) {
 				return nil
 			}
 
-			if !strings.Contains(fpath, "vendor") && !strings.Contains(fpath, "tests") {
+			// 7 is length of 'vendor' (6) + length of file path separator (1)
+			// so we skip dir 'vendor' which is directly under dirpath
+			if !(len(fpath) == len(dirpath)+7 && strings.HasSuffix(fpath, "vendor")) &&
+				!strings.Contains(fpath, "tests") &&
+				!(len(fpath) > len(dirpath) && fpath[len(dirpath)+1] == '.') {
 				err = parsePackageFromDir(fpath)
 				if err != nil {
 					// Send the error to through the channel and continue walking


### PR DESCRIPTION
Docs generator skips everything containing 'vendor' in path which is wrong. Fixed that to skip only the 'vendor' dir directly under the project root. Also don't even scan a dir beginning with a '.'