### PR TITLE
[Proposal] Database Migrations

### DIFF
--- a/cmd/commands/generate/generate.go
+++ b/cmd/commands/generate/generate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/beego/bee/config"
 	"github.com/beego/bee/generate"
 	"github.com/beego/bee/generate/swaggergen"
-	beeLogger "github.com/beego/bee/logger"
+	"github.com/beego/bee/logger"
 	"github.com/beego/bee/utils"
 )
 
@@ -71,6 +71,7 @@ func init() {
 	CmdGenerate.Flag.Var(&generate.SQLConn, "conn", "Connection string used by the SQLDriver to connect to a database instance.")
 	CmdGenerate.Flag.Var(&generate.Level, "level", "Either 1, 2 or 3. i.e. 1=models; 2=models and controllers; 3=models, controllers and routers.")
 	CmdGenerate.Flag.Var(&generate.Fields, "fields", "List of table Fields.")
+	CmdGenerate.Flag.Var(&generate.DDL, "ddl", "Generate DDL Migration")
 	commands.AvailableCommands = append(commands.AvailableCommands, CmdGenerate)
 }
 

--- a/generate/g.go
+++ b/generate/g.go
@@ -21,3 +21,4 @@ var SQLConn utils.DocValue
 var Level utils.DocValue
 var Tables utils.DocValue
 var Fields utils.DocValue
+var DDL utils.DocValue

--- a/generate/g_migration.go
+++ b/generate/g_migration.go
@@ -203,10 +203,12 @@ func GenerateMigration(mname, upsql, downsql, curpath string) {
 	fpath := path.Join(migrationFilePath, fmt.Sprintf("%s_%s.go", today, mname))
 	if f, err := os.OpenFile(fpath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0666); err == nil {
 		defer utils.CloseFile(f)
+		ddlSpec := ""
 		spec := ""
 		up := ""
 		down := ""
 		if DDL != "" {
+			ddlSpec = "m.ddlSpec()"
 			switch strings.Title(DDL.String()) {
 			case "Create":
 				spec = strings.Replace(DDLSpecCreate, "{{StructName}}", utils.CamelCase(mname)+"_"+today, -1)
@@ -222,6 +224,7 @@ func GenerateMigration(mname, upsql, downsql, curpath string) {
 		}
 
 		header := strings.Replace(MigrationHeader, "{{StructName}}", utils.CamelCase(mname)+"_"+today, -1)
+		header = strings.Replace(header, "{{ddlSpec}}", ddlSpec, -1)
 		header = strings.Replace(header, "{{CurrTime}}", today, -1)
 		f.WriteString(header + spec + up + down)
 		// Run 'gofmt' on the generated source code
@@ -247,6 +250,7 @@ const (
 						func init() {
 							m := &{{StructName}}{}
 							m.Created = "{{CurrTime}}"
+							{{ddlSpec}}
 							migration.Register("{{StructName}}", m)
 						}
 					   `

--- a/generate/g_migration.go
+++ b/generate/g_migration.go
@@ -212,7 +212,6 @@ func GenerateMigration(mname, upsql, downsql, curpath string) {
 			switch strings.Title(DDL.String()) {
 			case "Create":
 				spec = strings.Replace(DDLSpecCreate, "{{StructName}}", utils.CamelCase(mname)+"_"+today, -1)
-				break
 			case "Alter":
 				spec = strings.Replace(DDLSpecAlter, "{{StructName}}", utils.CamelCase(mname)+"_"+today, -1)
 			}

--- a/generate/g_migration.go
+++ b/generate/g_migration.go
@@ -203,12 +203,10 @@ func GenerateMigration(mname, upsql, downsql, curpath string) {
 	fpath := path.Join(migrationFilePath, fmt.Sprintf("%s_%s.go", today, mname))
 	if f, err := os.OpenFile(fpath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0666); err == nil {
 		defer utils.CloseFile(f)
-		ddlSpec := ""
 		spec := ""
 		up := ""
 		down := ""
 		if DDL != "" {
-			ddlSpec = "m.ddlSpec()"
 			switch strings.Title(DDL.String()) {
 			case "Create":
 				spec = strings.Replace(DDLSpecCreate, "{{StructName}}", utils.CamelCase(mname)+"_"+today, -1)
@@ -224,7 +222,6 @@ func GenerateMigration(mname, upsql, downsql, curpath string) {
 		}
 
 		header := strings.Replace(MigrationHeader, "{{StructName}}", utils.CamelCase(mname)+"_"+today, -1)
-		header = strings.Replace(header, "{{ddlSpec}}", ddlSpec, -1)
 		header = strings.Replace(header, "{{CurrTime}}", today, -1)
 		f.WriteString(header + spec + up + down)
 		// Run 'gofmt' on the generated source code
@@ -250,7 +247,6 @@ const (
 						func init() {
 							m := &{{StructName}}{}
 							m.Created = "{{CurrTime}}"
-							{{ddlSpec}}
 							migration.Register("{{StructName}}", m)
 						}
 					   `


### PR DESCRIPTION
SUMMARY: The DDL migration can now be generated by adding a `-ddl` and a
proper "alter" or "create" as argument value.

Migration generation had been modified to accommodate the complementary
code for ddl generation

Complements Proposal for Database Migrations on astaxie/beego#2743 and PR for Database Migrations on astaxie/beego#2744

Signed-off-by: Gnanakeethan Balasubramaniam <gnanakeethan@gmail.com>