### PR TITLE
array的格式

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -613,7 +613,7 @@ func parserComments(f *ast.FuncDecl, controllerName, pkgpath string) error {
 				typ := pp[len(pp)-1]
 				if len(pp) >= 2 {
 					isArray := false
-					if (p[1] == "body" || p[1] == "formData") && strings.HasPrefix(p[2], "[]") {
+					if p[1] == "body" && strings.HasPrefix(p[2], "[]") {
 						p[2] = p[2][2:]
 						isArray = true
 					}

--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -613,7 +613,7 @@ func parserComments(f *ast.FuncDecl, controllerName, pkgpath string) error {
 				typ := pp[len(pp)-1]
 				if len(pp) >= 2 {
 					isArray := false
-					if p[1] == "body" || p[1] == "formData" || strings.HasPrefix(p[2], "[]") {
+					if (p[1] == "body" || p[1] == "formData") && strings.HasPrefix(p[2], "[]") {
 						p[2] = p[2][2:]
 						isArray = true
 					}

--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -777,12 +777,20 @@ func setParamType(para *swagger.Parameter, typ string, pkgpath, controllerName s
 		appendModels(pkgpath, controllerName, realTypes)
 	}
 	if isArray {
-		para.Schema = &swagger.Schema{
-			Type: "array",
-			Items: &swagger.Schema{
+		if para.In == "body" {
+			para.Schema = &swagger.Schema{
+				Type: "array",
+				Items: &swagger.Schema{
+					Type:   paraType,
+					Format: paraFormat,
+				},
+			}
+		} else {
+			para.Type = "array"
+			para.Items = &swagger.ParameterItems{
 				Type:   paraType,
 				Format: paraFormat,
-			},
+			}
 		}
 	} else {
 		para.Type = paraType


### PR DESCRIPTION
你好
我在使用bee生成swagger.json时对以下注释：
```
// @Param   body            body    []controllers.Teststruct true    "test"
生成的参数格式是：
parameters: [
	{
		in: "body",
		name: "body",
		description: "test",
		required: true,
		schema: {
			$ref: "#/definitions/controllers.Teststruct"
		}
	}
],
```
而不是数组，
对以下注释：
```
// @Param   body            body    []string    true    "test"
生成的参数是：
parameters: [
	{
		in: "body",
		name: "body",
		description: "test",
		required: true,
		type: "array",
		items: {
			type: "string"
		}
	}
],
```
使用swaggerui没有正确的显示：
![image](https://user-images.githubusercontent.com/5327610/28354444-79efd5ba-6c92-11e7-8879-94c493f90be1.png)
更改为：
```
"parameters": [
                    {
                        "in": "body",
                        "name": "body",
                        "description": "test",
                        "required": true,
                        "schema": {
                            "type": "array",
                            "items": {
                                "type": "string"
                            }
                        }
                    }
                ],
```
后显示正确了
![image](https://user-images.githubusercontent.com/5327610/28354749-a1ce7aae-6c93-11e7-8d0b-ec769bfbde7f.png)

我尝试修改了g_docs.go，请辛苦review下