### PR TITLE
Do no omit response description

### DIFF
--- a/vendor/github.com/astaxie/beego/swagger/swagger.go
+++ b/vendor/github.com/astaxie/beego/swagger/swagger.go
@@ -141,7 +141,7 @@ type Propertie struct {
 
 // Response as they are returned from executing this operation.
 type Response struct {
-	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Description string  `json:"description" yaml:"description"`
 	Schema      *Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Ref         string  `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 }


### PR DESCRIPTION
[swagger specs](https://swagger.io/docs/specification/describing-responses/) requires each response to have a description. Otherwise, ignorable error will be generated. This PR makes sure that description field is not omitted in the event that user did not give a description.