### PR TITLE
Generate multipart/form-data consumer for API doc

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -678,6 +678,7 @@ func parserComments(f *ast.FuncDecl, controllerName, pkgpath string) error {
 						opts.Produces = append(opts.Produces, ahtml)
 					case "form":
 						opts.Consumes = append(opts.Consumes, aform)
+						opts.Consumes = append(opts.Consumes, ajson)
 					}
 				}
 			} else if strings.HasPrefix(t, "@Security") {

--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -44,6 +44,7 @@ const (
 	axml   = "application/xml"
 	aplain = "text/plain"
 	ahtml  = "text/html"
+	aform  = "multipart/form-data"
 )
 
 var pkgCache map[string]struct{} //pkg:controller:function:comments comments: key:value
@@ -675,6 +676,8 @@ func parserComments(f *ast.FuncDecl, controllerName, pkgpath string) error {
 					case "html":
 						opts.Consumes = append(opts.Consumes, ahtml)
 						opts.Produces = append(opts.Produces, ahtml)
+					case "form":
+						opts.Consumes = append(opts.Consumes, aform)
 					}
 				}
 			} else if strings.HasPrefix(t, "@Security") {

--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -678,7 +678,6 @@ func parserComments(f *ast.FuncDecl, controllerName, pkgpath string) error {
 						opts.Produces = append(opts.Produces, ahtml)
 					case "form":
 						opts.Consumes = append(opts.Consumes, aform)
-						opts.Consumes = append(opts.Consumes, ajson)
 					}
 				}
 			} else if strings.HasPrefix(t, "@Security") {


### PR DESCRIPTION
Bee automated API doc generator doesn't generate consumer for forms.

Look at this page in swagger docs: https://swagger.io/docs/specification/file-upload/

And here is a sample example:
```go
// @Title Upload one file
// @Description Register region to system
// @Security AdministratorToken
// @Accept form
// @Param   	file	formData   	file	true       	"Upload File"
// @Success 201 jsons.UploadV1
// @Failure 400 Bad Request
// @Failure 401 Unauthorized
// @router / [post]
func (u *UploadControllerV1) UploadOne() {
	if _, _, err := u.GetFile("file"); err == nil {
		// get the filename
		//fileName := header.Filename
		// save to server
		u.SaveToFile("file", beego.AppConfig.DefaultString("UploadTo", "data/uploads/test"))
		fmt.Println("Heelo")
	} else if err == http.ErrMissingFile {
		u.Abort("400")
	} else {
		fmt.Println(err)
	}
}
```