### PR TITLE
make bee migrate compatible with MariaDB V10.2.9

### DIFF
--- a/cmd/commands/migrate/migrate.go
+++ b/cmd/commands/migrate/migrate.go
@@ -187,8 +187,8 @@ func checkForSchemaUpdateTable(db *sql.DB, driver string) {
 					beeLogger.Log.Fatalf("Column migration.name type mismatch: TYPE: %s, NULL: %s", typeStr, nullStr)
 				}
 			} else if fieldStr == "created_at" {
-				if typeStr != "timestamp" || defaultStr != "CURRENT_TIMESTAMP" {
-					beeLogger.Log.Hint("Expecting TYPE: timestamp, DEFAULT: CURRENT_TIMESTAMP")
+				if typeStr != "timestamp" || (defaultStr != "CURRENT_TIMESTAMP" && defaultStr != "CURRENT_TIMESTAMP()") {
+					beeLogger.Log.Hint("Expecting TYPE: timestamp, DEFAULT: CURRENT_TIMESTAMP || CURRENT_TIMESTAMP()")
 					beeLogger.Log.Fatalf("Column migration.timestamp type mismatch: TYPE: %s, DEFAULT: %s", typeStr, defaultStr)
 				}
 			}

--- a/cmd/commands/migrate/migrate.go
+++ b/cmd/commands/migrate/migrate.go
@@ -187,7 +187,7 @@ func checkForSchemaUpdateTable(db *sql.DB, driver string) {
 					beeLogger.Log.Fatalf("Column migration.name type mismatch: TYPE: %s, NULL: %s", typeStr, nullStr)
 				}
 			} else if fieldStr == "created_at" {
-				if typeStr != "timestamp" || (defaultStr != "CURRENT_TIMESTAMP" && defaultStr != "CURRENT_TIMESTAMP()") {
+				if typeStr != "timestamp" || ((defaultStr != "CURRENT_TIMESTAMP") && (defaultStr != "CURRENT_TIMESTAMP()")) {
 					beeLogger.Log.Hint("Expecting TYPE: timestamp, DEFAULT: CURRENT_TIMESTAMP || CURRENT_TIMESTAMP()")
 					beeLogger.Log.Fatalf("Column migration.timestamp type mismatch: TYPE: %s, DEFAULT: %s", typeStr, defaultStr)
 				}

--- a/cmd/commands/version/version.go
+++ b/cmd/commands/version/version.go
@@ -57,7 +57,7 @@ Prints the current Bee, Beego and Go version alongside the platform information.
 }
 var outputFormat string
 
-const version = "1.9.1"
+const version = "1.9.2"
 
 func init() {
 	fs := flag.NewFlagSet("version", flag.ContinueOnError)


### PR DESCRIPTION
    MariaDB will show "current_timestamp()" instead of MySQL's
    "current_timestamp"
    Bee should work well with both of those

fix #477 

