### PR TITLE
Convert error on Swagger Generate

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -261,8 +261,9 @@ func GenerateDocs(curpath string) {
 				case *ast.AssignStmt:
 					for _, l := range stmt.Rhs {
 						if v, ok := l.(*ast.CallExpr); ok {
-							// Analyse NewNamespace, it will return version and the subfunction
-							if selName := v.Fun.(*ast.SelectorExpr).Sel.String(); selName != "NewNamespace" {
+							// Analyze NewNamespace, it will return version and the subfunction
+							selExpr, selOK := v.Fun.(*ast.SelectorExpr)
+							if !selOK || selExpr.Sel.Name != "NewNamespace" {
 								continue
 							}
 							version, params := analyseNewNamespace(v)


### PR DESCRIPTION
Sometimes when generating swagger router, I get the following error; 
panic:  interface conversion: ast.Expr is *ast.Ident, not *ast.SelectorExpr

v.Fun can't always be converted to *ast.SelectorExpr. 
Added a check to confirm that the object is SelectorExpr and NOT Ident