### PR TITLE
Swagger docs generation improvement.

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -927,6 +927,21 @@ func parseObject(d *ast.Object, k string, m *swagger.Schema, realTypes *[]string
 	}
 	// TODO support other types, such as `ArrayType`, `MapType`, `InterfaceType` etc...
 	switch t := ts.Type.(type) {
+	case *ast.ArrayType:
+		m.Title = k
+		m.Type = "array"
+		if isBasicType(fmt.Sprint(t.Elt)) {
+			typeFormat := strings.Split(basicTypes[fmt.Sprint(t.Elt)], ":")
+			m.Format = typeFormat[0]
+		} else {
+			objectName := packageName + "." + fmt.Sprint(t.Elt)
+			if _, ok := rootapi.Definitions[objectName]; !ok {
+				objectName, _, _ = getModel(objectName)
+			}
+			m.Items = &swagger.Schema{
+				Ref: "#/definitions/" + objectName,
+			}
+		}
 	case *ast.Ident:
 		parseIdent(t, k, m, astPkgs)
 	case *ast.StructType:


### PR DESCRIPTION
1. Example value for enum will be type sensitive, it won't just just a string.
2. ArrayType definition is now supported. e.g. You can define the following:
```
package models
......

type SliceStringField []string
```
The swagger definition generated will be 
```
"models.SliceStringField": {
            "title": "SliceStringField",
            "format": "string",
            "type": "array"
        },
```

Previously, nothing will get generated, those kind of definition will simply get skipped.

3. Complicated ArrayType definition is now supported. e.g. You can do the following:
```
package models
......

type Marker struct {
	ElementID        string      `json:"elementID"`
}

type Markers []Marker
```
The swagger definition generated will be
```
"models.Marker": {
            "title": "Marker",
            "type": "object",
            "properties": {
                "elementID": {
                    "type": "string"
                }
            }
},
"models.Markers": {
            "title": "Markers",
            "type": "array",
            "items": {
                "$ref": "#/definitions/models.Marker"
            }
}
```

Previously, nothing will get generated, those kind of definition will simply get skipped.