### PR TITLE
fix api path contain regex string bug

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -1100,6 +1100,12 @@ func urlReplace(src string) string {
 			} else if p[0] == '?' && p[1] == ':' {
 				pt[i] = "{" + p[2:] + "}"
 			}
+
+			if pt[i][0] == '{' && strings.Contains(pt[i], ":") {
+				pt[i] = pt[i][:strings.Index(pt[i], ":")] + "}"
+			} else if pt[i][0] == '{' && strings.Contains(pt[i], "(") {
+				pt[i] = pt[i][:strings.Index(pt[i], "(")] + "}"
+			}
 		}
 	}
 	return strings.Join(pt, "/")


### PR DESCRIPTION
Bug desc below:
When the controller @router contain regex string, such as "/:userid([0-9]+)" .It would set the swagger.yml file path value as /{userid([0-9]+)}. 