### PR TITLE
Update ignoredFilesRegExps

### DIFF
--- a/cmd/commands/run/watch.go
+++ b/cmd/commands/run/watch.go
@@ -43,6 +43,7 @@ var (
 		`.(\w+).go.swp`,
 		`(\w+).go~`,
 		`(\w+).tmp`,
+		`commentsRouter_controllers.go`,
 	}
 )
 


### PR DESCRIPTION
解决了在执行 `bee run -gendoc=true` 时，更新`commentsRouter_controllers.go`文件导致多次触发"build"的bug。