### PR TITLE
Update watch.go

### DIFF
--- a/cmd/commands/run/watch.go
+++ b/cmd/commands/run/watch.go
@@ -139,9 +139,9 @@ func AutoBuild(files []string, isgenerate bool) {
 		}
 		beeLogger.Log.Success("Docs generated!")
 	}
-
+	appName := appname
 	if err == nil {
-		appName := appname
+		
 		if runtime.GOOS == "windows" {
 			appName += ".exe"
 		}
@@ -165,7 +165,7 @@ func AutoBuild(files []string, isgenerate bool) {
 	}
 
 	beeLogger.Log.Success("Built Successfully!")
-	Restart(appname)
+	Restart(appName)
 }
 
 // Kill kills the running command process


### PR DESCRIPTION
fix:在window下编译linux后,bee run 执行的appname为linux的可执行文件