### PR TITLE
fix bee.json & Beefile watch_ext doesn't work

### DIFF
--- a/Beefile
+++ b/Beefile
@@ -1,6 +1,7 @@
 version: 0
 go_install: false
-watch_ext: []
+watch_ext: [".go"]
+watch_ext_static: [".html", ".tpl", ".js", ".css"]
 dir_structure:
   watch_all: false
   controllers: ""

--- a/bee.json
+++ b/bee.json
@@ -1,7 +1,8 @@
 {
 	"version": 0,
 	"go_install": false,
-	"watch_ext": [],
+	"watch_ext": [".go"],
+	"watch_ext_static": [".html", ".tpl", ".js", ".css"],
 	"dir_structure": {
 		"watch_all": false,
 		"controllers": "",

--- a/cmd/commands/run/watch.go
+++ b/cmd/commands/run/watch.go
@@ -36,8 +36,8 @@ var (
 	state               sync.Mutex
 	eventTime           = make(map[string]int64)
 	scheduleTime        time.Time
-	watchExts           = []string{".go"}
-	watchExtsStatic     = []string{".html", ".tpl", ".js", ".css"}
+	watchExts           = config.Conf.WatchExts
+	watchExtsStatic     = config.Conf.WatchExtsStatic
 	ignoredFilesRegExps = []string{
 		`.#(\w+).go`,
 		`.(\w+).go.swp`,

--- a/config/conf.go
+++ b/config/conf.go
@@ -27,6 +27,8 @@ const confVer = 0
 
 var Conf = struct {
 	Version            int
+	WatchExts          []string  `json:"watch_ext" yaml:"watch_ext"`
+	WatchExtsStatic    []string  `json:"watch_ext_static" yaml:"watch_ext_static"`
 	GoInstall          bool      `json:"go_install" yaml:"go_install"` // Indicates whether execute "go install" before "go build".
 	DirStruct          dirStruct `json:"dir_structure" yaml:"dir_structure"`
 	CmdArgs            []string  `json:"cmd_args" yaml:"cmd_args"`
@@ -37,7 +39,9 @@ var Conf = struct {
 	EnableNotification bool              `json:"enable_notification" yaml:"enable_notification"`
 	Scripts            map[string]string `json:"scripts" yaml:"scripts"`
 }{
-	GoInstall: true,
+	WatchExts:       []string{".go"},
+	WatchExtsStatic: []string{".html", ".tpl", ".js", ".css"},
+	GoInstall:       true,
 	DirStruct: dirStruct{
 		Others: []string{},
 	},


### PR DESCRIPTION
I want watch `conf/app.conf` file, it doesn't work when I add `watch_ext` param to `bee.json`. 

Now, if you want `bee` command to watch the `conf/app.conf` file, you need to make a file `bee.json` at your app directory and the content should like this:

**bee.json**
```
{
	"version": 0,
	"go_install": false,
	"watch_ext": [".go", ".conf"],
	"dir_structure": {
		"watch_all": false,
		"controllers": "",
		"models": "",
		"others": ["conf/"]
	},
	"cmd_args": [],
	"envs": [],
	"database": {
		"driver": "mysql"
	},
	"enable_reload": false
}
```