### PR TITLE
Adding a --dir option to migrate command to change migration directory

### DIFF
--- a/cmd/commands/migrate/migrate.go
+++ b/cmd/commands/migrate/migrate.go
@@ -38,19 +38,19 @@ var CmdMigrate = &commands.Command{
 
   ▶ {{"To run all the migrations:"|bold}}
 
-    $ bee migrate [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
+    $ bee migrate [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"] [-dir="path/to/migration"]
 
   ▶ {{"To rollback the last migration:"|bold}}
 
-    $ bee migrate rollback [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
+    $ bee migrate rollback [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"] [-dir="path/to/migration"]
 
   ▶ {{"To do a reset, which will rollback all the migrations:"|bold}}
 
-    $ bee migrate reset [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
+    $ bee migrate reset [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"] [-dir="path/to/migration"]
 
   ▶ {{"To update your schema:"|bold}}
 
-    $ bee migrate refresh [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
+    $ bee migrate refresh [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"] [-dir="path/to/migration"]
 `,
 	PreRun: func(cmd *commands.Command, args []string) { version.ShowShortVersionBanner() },
 	Run:    RunMigration,

--- a/cmd/commands/migrate/migrate.go
+++ b/cmd/commands/migrate/migrate.go
@@ -98,11 +98,22 @@ func RunMigration(cmd *commands.Command, args []string) int {
 	}
 	if mDir == "" {
 		mDir = utils.DocValue(config.Conf.Database.Dir)
+		if mDir == "" {
+			mDir = utils.DocValue(path.Join(currpath, "database", "migrations"))
+		}
 	}
+
 	beeLogger.Log.Infof("Using '%s' as 'driver'", mDriver)
 	beeLogger.Log.Infof("Using '%s' as 'conn'", mConn)
 	beeLogger.Log.Infof("Using '%s' as 'dir'", mDir)
 	driverStr, connStr, dirStr := string(mDriver), string(mConn), string(mDir)
+
+	dirRune := []rune(dirStr)
+
+	if dirRune[0] != '/' && dirRune[1] != ':' {
+		dirStr = path.Join(currpath, dirStr)
+	}
+
 	if len(args) == 0 {
 		// run all outstanding migrations
 		beeLogger.Log.Info("Running all outstanding migrations")

--- a/cmd/commands/migrate/migrate.go
+++ b/cmd/commands/migrate/migrate.go
@@ -58,10 +58,12 @@ var CmdMigrate = &commands.Command{
 
 var mDriver utils.DocValue
 var mConn utils.DocValue
+var mDir utils.DocValue
 
 func init() {
 	CmdMigrate.Flag.Var(&mDriver, "driver", "Database driver. Either mysql, postgres or sqlite.")
 	CmdMigrate.Flag.Var(&mConn, "conn", "Connection string used by the driver to connect to a database instance.")
+	CmdMigrate.Flag.Var(&mDir, "dir", "The directory where the migration files are stored")
 	commands.AvailableCommands = append(commands.AvailableCommands, CmdMigrate)
 }
 
@@ -94,25 +96,29 @@ func RunMigration(cmd *commands.Command, args []string) int {
 			mConn = "root:@tcp(127.0.0.1:3306)/test"
 		}
 	}
+	if mDir == "" {
+		mDir = utils.DocValue(config.Conf.Database.Dir)
+	}
 	beeLogger.Log.Infof("Using '%s' as 'driver'", mDriver)
 	beeLogger.Log.Infof("Using '%s' as 'conn'", mConn)
-	driverStr, connStr := string(mDriver), string(mConn)
+	beeLogger.Log.Infof("Using '%s' as 'dir'", mDir)
+	driverStr, connStr, dirStr := string(mDriver), string(mConn), string(mDir)
 	if len(args) == 0 {
 		// run all outstanding migrations
 		beeLogger.Log.Info("Running all outstanding migrations")
-		MigrateUpdate(currpath, driverStr, connStr)
+		MigrateUpdate(currpath, driverStr, connStr, dirStr)
 	} else {
 		mcmd := args[0]
 		switch mcmd {
 		case "rollback":
 			beeLogger.Log.Info("Rolling back the last migration operation")
-			MigrateRollback(currpath, driverStr, connStr)
+			MigrateRollback(currpath, driverStr, connStr, dirStr)
 		case "reset":
 			beeLogger.Log.Info("Reseting all migrations")
-			MigrateReset(currpath, driverStr, connStr)
+			MigrateReset(currpath, driverStr, connStr, dirStr)
 		case "refresh":
 			beeLogger.Log.Info("Refreshing all migrations")
-			MigrateRefresh(currpath, driverStr, connStr)
+			MigrateRefresh(currpath, driverStr, connStr, dirStr)
 		default:
 			beeLogger.Log.Fatal("Command is missing")
 		}
@@ -122,8 +128,10 @@ func RunMigration(cmd *commands.Command, args []string) int {
 }
 
 // migrate generates source code, build it, and invoke the binary who does the actual migration
-func migrate(goal, currpath, driver, connStr string) {
-	dir := path.Join(currpath, "database", "migrations")
+func migrate(goal, currpath, driver, connStr, dir string) {
+	if dir == "" {
+		dir = path.Join(currpath, "database", "migrations")
+	}
 	postfix := ""
 	if runtime.GOOS == "windows" {
 		postfix = ".exe"
@@ -415,21 +423,21 @@ CREATE TABLE migrations (
 )
 
 // MigrateUpdate does the schema update
-func MigrateUpdate(currpath, driver, connStr string) {
-	migrate("upgrade", currpath, driver, connStr)
+func MigrateUpdate(currpath, driver, connStr, dir string) {
+	migrate("upgrade", currpath, driver, connStr, dir)
 }
 
 // MigrateRollback rolls back the latest migration
-func MigrateRollback(currpath, driver, connStr string) {
-	migrate("rollback", currpath, driver, connStr)
+func MigrateRollback(currpath, driver, connStr, dir string) {
+	migrate("rollback", currpath, driver, connStr, dir)
 }
 
 // MigrateReset rolls back all migrations
-func MigrateReset(currpath, driver, connStr string) {
-	migrate("reset", currpath, driver, connStr)
+func MigrateReset(currpath, driver, connStr, dir string) {
+	migrate("reset", currpath, driver, connStr, dir)
 }
 
 // migrationRefresh rolls back all migrations and start over again
-func MigrateRefresh(currpath, driver, connStr string) {
-	migrate("refresh", currpath, driver, connStr)
+func MigrateRefresh(currpath, driver, connStr, dir string) {
+	migrate("refresh", currpath, driver, connStr, dir)
 }

--- a/config/conf.go
+++ b/config/conf.go
@@ -77,6 +77,7 @@ type bale struct {
 type database struct {
 	Driver string
 	Conn   string
+	Dir    string
 }
 
 // LoadConfig loads the bee tool configuration.

--- a/generate/g_scaffold.go
+++ b/generate/g_scaffold.go
@@ -44,7 +44,7 @@ func GenerateScaffold(sname, fields, currpath, driver, conn string) {
 	// Run the migration
 	beeLogger.Log.Infof("Do you want to migrate the database? [Yes|No] ")
 	if utils.AskForConfirmation() {
-		migrate.MigrateUpdate(currpath, driver, conn)
+		migrate.MigrateUpdate(currpath, driver, conn, "")
 	}
 	beeLogger.Log.Successf("All done! Don't forget to add  beego.Router(\"/%s\" ,&controllers.%sController{}) to routers/route.go\n", sname, strings.Title(sname))
 }


### PR DESCRIPTION
This PR adds a --dir option to change the directory where it searches for migrations. 
This can be useful when there is a setup with different databases and there need to be different migrations for these dbs.

The option falls back to database/migations

Also the option accepts either (project-) relative or absolute paths

