### PR TITLE
调整bee help api展示内容的问题

### DIFF
--- a/cmd/commands/api/apiapp.go
+++ b/cmd/commands/api/apiapp.go
@@ -35,7 +35,7 @@ var CmdApiapp = &commands.Command{
   The command 'api' creates a Beego API application.
 
   {{"Example:"|bold}}
-      $ bee api [appname] [-tables=""] [-driver=mysql] [-conn=root:@tcp(127.0.0.1:3306)/test]
+      $ bee api [appname] [-tables=""] [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
 
   If 'conn' argument is empty, the command will generate an example API application. Otherwise the command
   will connect to your database and generate models based on the existing tables.

--- a/cmd/commands/hprose/hprose.go
+++ b/cmd/commands/hprose/hprose.go
@@ -24,7 +24,7 @@ var CmdHproseapp = &commands.Command{
 
   {{"To scaffold out your application, use:"|bold}}
 
-      $ bee hprose [appname] [-tables=""] [-driver=mysql] [-conn=root:@tcp(127.0.0.1:3306)/test]
+      $ bee hprose [appname] [-tables=""] [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
 
   If 'conn' is empty, the command will generate a sample application. Otherwise the command
   will connect to your database and generate models based on the existing tables.


### PR DESCRIPTION
帮助展示的-conn=root:@tcp(127.0.0.1:3306)/test无双引号会报错。