### PR TITLE
When restarting, terminate process gracefully

### DIFF
--- a/cmd/commands/run/watch.go
+++ b/cmd/commands/run/watch.go
@@ -183,7 +183,6 @@ func Kill() {
 		}
 	}()
 	if cmd != nil && cmd.Process != nil {
-		//err := cmd.Process.Kill()
 		cmd.Process.Signal(os.Interrupt)
 		ch := make(chan struct{}, 1)
 		go func() {
@@ -195,7 +194,10 @@ func Kill() {
 			return
 		case <-time.After(10 * time.Second):
 			beeLogger.Log.Info("Timeout; Force kill cmd process")
-			cmd.Process.Kill()
+			err := cmd.Process.Kill()
+			if err != nil {
+				beeLogger.Log.Errorf("Error while killing cmd process: %s", err)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
When `bee run` is executed and the source code is modified, 
watcher detects the change and restarts the process.

Calling `Kill()` at this time will terminate the process with `syscall.SIGKILL`, not `syscall.SIGINT`.
And it does not gracefully terminate the process.
As a result, at the end of the process, do not perform defer operations and files such as lock are not deleted normally.
The result affects to restart and does not normally execute the process.

so i fixed it:
first, try to kill it with `syscall.SIGINT`, and if it does not finish after a while, kill with `syscall.SIGKILL`.
