### PR TITLE
Fix for projects with 'tests' in path

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -119,7 +119,7 @@ func ParsePackagesFromDir(dirpath string) {
 			// all 'tests' folders and dot folders wihin dirpath
 			d, _ := filepath.Rel(dirpath, fpath)
 			if !(d == "vendor" || strings.HasPrefix(d, "vendor"+string(os.PathSeparator))) &&
-				!strings.Contains(fpath, "tests") &&
+				!strings.Contains(d, "tests") &&
 				!(d[0] == '.') {
 				err = parsePackageFromDir(fpath)
 				if err != nil {


### PR DESCRIPTION
Projects with the string 'tests' in their path cannot document their models properly in swaggergen.  The comment says the 'tests' subfolder within the dirpath should be excluded, but the test was for the full path.  This should fix the discrepancy.