### PR TITLE
add parms for go executable file path!

### DIFF
--- a/cmd/commands/dlv/dlv_amd64.go
+++ b/cmd/commands/dlv/dlv_amd64.go
@@ -228,7 +228,7 @@ func startWatcher(paths []string, ch chan int) {
 
 					// Wait 1s before re-build until there is no file change
 					scheduleTime := time.Now().Add(1 * time.Second)
-					time.Sleep(scheduleTime.Sub(time.Now()))
+					time.Sleep(time.Until(scheduleTime))
 					_, err := buildDebug()
 					if err != nil {
 						utils.Notify("Build Failed: "+err.Error(), "bee")

--- a/cmd/commands/migrate/migrate.go
+++ b/cmd/commands/migrate/migrate.go
@@ -38,19 +38,19 @@ var CmdMigrate = &commands.Command{
 
   ▶ {{"To run all the migrations:"|bold}}
 
-    $ bee migrate [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
+    $ bee migrate [-gobin=go] [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
 
   ▶ {{"To rollback the last migration:"|bold}}
 
-    $ bee migrate rollback [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
+    $ bee migrate rollback [-gobin=go] [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
 
   ▶ {{"To do a reset, which will rollback all the migrations:"|bold}}
 
-    $ bee migrate reset [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
+    $ bee migrate reset [-gobin=go] [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
 
   ▶ {{"To update your schema:"|bold}}
 
-    $ bee migrate refresh [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
+    $ bee migrate refresh [-gobin=go] [-driver=mysql] [-conn="root:@tcp(127.0.0.1:3306)/test"]
 `,
 	PreRun: func(cmd *commands.Command, args []string) { version.ShowShortVersionBanner() },
 	Run:    RunMigration,
@@ -58,8 +58,10 @@ var CmdMigrate = &commands.Command{
 
 var mDriver utils.DocValue
 var mConn utils.DocValue
+var cmdName = utils.DocValue("go")
 
 func init() {
+	CmdMigrate.Flag.Var(&cmdName, "gobin", "go executable file path or alias")
 	CmdMigrate.Flag.Var(&mDriver, "driver", "Database driver. Either mysql, postgres or sqlite.")
 	CmdMigrate.Flag.Var(&mConn, "conn", "Connection string used by the driver to connect to a database instance.")
 	commands.AvailableCommands = append(commands.AvailableCommands, CmdMigrate)
@@ -289,7 +291,7 @@ func writeMigrationSourceFile(dir, source, driver, connStr string, latestTime in
 // buildMigrationBinary changes directory to database/migrations folder and go-build the source
 func buildMigrationBinary(dir, binary string) {
 	changeDir(dir)
-	cmd := exec.Command("go", "build", "-o", binary)
+	cmd := exec.Command(string(cmdName), "build", "-o", binary)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		beeLogger.Log.Errorf("Could not build migration binary: %s", err)
 		formatShellErrOutput(string(out))

--- a/cmd/commands/pack/pack.go
+++ b/cmd/commands/pack/pack.go
@@ -511,7 +511,7 @@ func packApp(cmd *commands.Command, args []string) int {
 			fmt.Fprintf(output, "\t%s%s+ go %s%s%s\n", "\x1b[32m", "\x1b[1m", strings.Join(args, " "), "\x1b[21m", "\x1b[0m")
 		}
 
-		execmd := exec.Command(string(cmdName), args...)
+		execmd := exec.Command(cmdName, args...)
 		execmd.Env = append(os.Environ(), envs...)
 		execmd.Stdout = os.Stdout
 		execmd.Stderr = os.Stderr

--- a/cmd/commands/pack/pack.go
+++ b/cmd/commands/pack/pack.go
@@ -53,8 +53,11 @@ var (
 	format    string
 )
 
+var cmdName = "go"
+
 func init() {
 	fs := flag.NewFlagSet("pack", flag.ContinueOnError)
+	fs.StringVar(&cmdName, "gobin", "go", "go executable file path or alias")
 	fs.StringVar(&appPath, "p", "", "Set the application path. Defaults to the current path.")
 	fs.BoolVar(&build, "b", true, "Tell the command to do a build for the current platform. Defaults to true.")
 	fs.StringVar(&buildArgs, "ba", "", "Specify additional args for Go build.")
@@ -508,7 +511,7 @@ func packApp(cmd *commands.Command, args []string) int {
 			fmt.Fprintf(output, "\t%s%s+ go %s%s%s\n", "\x1b[32m", "\x1b[1m", strings.Join(args, " "), "\x1b[21m", "\x1b[0m")
 		}
 
-		execmd := exec.Command("go", args...)
+		execmd := exec.Command(string(cmdName), args...)
 		execmd.Env = append(os.Environ(), envs...)
 		execmd.Stdout = os.Stdout
 		execmd.Stderr = os.Stderr

--- a/cmd/commands/run/run.go
+++ b/cmd/commands/run/run.go
@@ -28,7 +28,7 @@ import (
 )
 
 var CmdRun = &commands.Command{
-	UsageLine: "run [appname] [watchall] [-main=*.go] [-downdoc=true]  [-gendoc=true] [-vendor=true] [-e=folderToExclude] [-ex=extraPackageToWatch] [-tags=goBuildTags] [-runmode=BEEGO_RUNMODE]",
+	UsageLine: "run [-gobin=go] [appname] [watchall] [-main=*.go] [-downdoc=true]  [-gendoc=true] [-vendor=true] [-e=folderToExclude] [-ex=extraPackageToWatch] [-tags=goBuildTags] [-runmode=BEEGO_RUNMODE]",
 	Short:     "Run the application by starting a local development server",
 	Long: `
 Run command will supervise the filesystem of the application for any changes, and recompile/restart it.
@@ -64,8 +64,10 @@ var (
 	extraPackages utils.StrFlags
 )
 var started = make(chan bool)
+var cmdName = utils.DocValue("go")
 
 func init() {
+	CmdRun.Flag.Var(&cmdName, "gobin", "go executable file path or alias")
 	CmdRun.Flag.Var(&mainFiles, "main", "Specify main go files.")
 	CmdRun.Flag.Var(&gendoc, "gendoc", "Enable auto-generate the docs.")
 	CmdRun.Flag.Var(&downdoc, "downdoc", "Enable auto-download of the swagger file if it does not exist.")

--- a/cmd/commands/run/watch.go
+++ b/cmd/commands/run/watch.go
@@ -85,7 +85,7 @@ func NewWatcher(paths []string, files []string, isgenerate bool) {
 					go func() {
 						// Wait 1s before autobuild until there is no file change.
 						scheduleTime = time.Now().Add(1 * time.Second)
-						time.Sleep(scheduleTime.Sub(time.Now()))
+						time.Sleep(time.Until(scheduleTime))
 						AutoBuild(files, isgenerate)
 
 						if config.Conf.EnableReload {

--- a/cmd/commands/run/watch.go
+++ b/cmd/commands/run/watch.go
@@ -118,8 +118,6 @@ func AutoBuild(files []string, isgenerate bool) {
 
 	os.Chdir(currpath)
 
-	cmdName := "go"
-
 	var (
 		err    error
 		stderr bytes.Buffer
@@ -127,7 +125,7 @@ func AutoBuild(files []string, isgenerate bool) {
 	// For applications use full import path like "github.com/.../.."
 	// are able to use "go install" to reduce build time.
 	if config.Conf.GoInstall {
-		icmd := exec.Command(cmdName, "install", "-v")
+		icmd := exec.Command(string(cmdName), "install", "-v")
 		icmd.Stdout = os.Stdout
 		icmd.Stderr = os.Stderr
 		icmd.Env = append(os.Environ(), "GOGC=off")
@@ -148,7 +146,7 @@ func AutoBuild(files []string, isgenerate bool) {
 	}
 	appName := appname
 	if err == nil {
-		
+
 		if runtime.GOOS == "windows" {
 			appName += ".exe"
 		}
@@ -160,7 +158,7 @@ func AutoBuild(files []string, isgenerate bool) {
 		}
 		args = append(args, files...)
 
-		bcmd := exec.Command(cmdName, args...)
+		bcmd := exec.Command(string(cmdName), args...)
 		bcmd.Env = append(os.Environ(), "GOGC=off")
 		bcmd.Stderr = &stderr
 		err = bcmd.Run()

--- a/cmd/commands/version/version.go
+++ b/cmd/commands/version/version.go
@@ -48,7 +48,7 @@ const shortVersionBanner = `______
 `
 
 var CmdVersion = &commands.Command{
-	UsageLine: "version",
+	UsageLine: "version [-gobin=go] [-o=json] ",
 	Short:     "Prints the current Bee version",
 	Long: `
 Prints the current Bee, Beego and Go version alongside the platform information.
@@ -59,9 +59,12 @@ var outputFormat string
 
 const version = "1.10.0"
 
+var cmdName = "go"
+
 func init() {
 	fs := flag.NewFlagSet("version", flag.ContinueOnError)
 	fs.StringVar(&outputFormat, "o", "", "Set the output format. Either json or yaml.")
+	fs.StringVar(&cmdName, "gobin", "go", "go executable file path or alias")
 	CmdVersion.Flag = *fs
 	commands.AvailableCommands = append(commands.AvailableCommands, CmdVersion)
 }
@@ -168,7 +171,7 @@ func GetGoVersion() string {
 		err    error
 	)
 
-	if cmdOut, err = exec.Command("go", "version").Output(); err != nil {
+	if cmdOut, err = exec.Command(cmdName, "version").Output(); err != nil {
 		beeLogger.Log.Fatalf("There was an error running 'go version' command: %s", err)
 	}
 	return strings.Split(string(cmdOut), " ")[2]

--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -116,7 +116,7 @@ func ParsePackagesFromDir(dirpath string) {
 				err = parsePackageFromDir(fpath)
 				if err != nil {
 					// Send the error to through the channel and continue walking
-					c <- fmt.Errorf("Error while parsing directory: %s", err.Error())
+					c <- fmt.Errorf("error while parsing directory: %s", err.Error())
 					return nil
 				}
 			}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -328,7 +328,7 @@ func CheckEnv(appname string) (apppath, packpath string, err error) {
 	apppath = filepath.Join(gosrcpath, appname)
 
 	if _, e := os.Stat(apppath); !os.IsNotExist(e) {
-		err = fmt.Errorf("Cannot create application without removing '%s' first", apppath)
+		err = fmt.Errorf("cannot create application without removing '%s' first", apppath)
 		beeLogger.Log.Errorf("Path '%s' already exists", apppath)
 		return
 	}


### PR DESCRIPTION
在我运行的linux机器上， go 命令被用作了 跳板机的跳转工具。通常需要指定go的完全路径才能正常工作。所有给bee加上了参数可以填入go的路径。
可能一般人用不到，不过多个版本的go也可以用啊。