### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/cmd/commands/migrate/migrate.go
+++ b/cmd/commands/migrate/migrate.go
@@ -448,7 +448,7 @@ func MigrateReset(currpath, driver, connStr, dir string) {
 	migrate("reset", currpath, driver, connStr, dir)
 }
 
-// migrationRefresh rolls back all migrations and start over again
+// MigrateRefresh rolls back all migrations and start over again
 func MigrateRefresh(currpath, driver, connStr, dir string) {
 	migrate("refresh", currpath, driver, connStr, dir)
 }


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?