### PR TITLE
[Fix] Fix swagger docs missing schema attr for primitive body type param

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -791,10 +791,21 @@ func setParamType(para *swagger.Parameter, typ string, pkgpath, controllerName s
 	if typ == "string" || typ == "number" || typ == "integer" || typ == "boolean" ||
 		typ == astTypeArray || typ == "file" {
 		paraType = typ
+		if para.In == "body" {
+			para.Schema = &swagger.Schema{
+				Type: paraType,
+			}
+		}
 	} else if sType, ok := basicTypes[typ]; ok {
 		typeFormat := strings.Split(sType, ":")
 		paraType = typeFormat[0]
 		paraFormat = typeFormat[1]
+		if para.In == "body" {
+			para.Schema = &swagger.Schema{
+				Type: paraType,
+				Format: paraFormat,
+			}
+		}
 	} else {
 		m, mod, realTypes := getModel(typ)
 		para.Schema = &swagger.Schema{


### PR DESCRIPTION
Hi core maintainer

I hit a problem with Bee tool while generating swagger documents based on controller annotations. I would like to contribute the fix for this. Please kindly review and merge if it is good.

 ## Problem Description
When a `@Param` annotation is parsed for a body parameter definition of basic type, the generated swagger specs missing necessary attributes for SwaggerUI to work properly. To be explicit:  

`// @Param application_profile body string true "Profile of application to be registered"` . 

Such an annotation generates swagger specs as :
```
                "parameters": [
                    {
                        "in": "body",
                        "name": "application_profile",
                        "description": "Profile of application to be registered",
                        "required": true,
                        "type": "string"
                    },
```
This spec misses necessary `schema` attribute so that the SwaggerUI can not let user input value for this parameter. Please refer to the attached screenshot `wrong.png`
<img width="1425" alt="wrong" src="https://user-images.githubusercontent.com/5110431/55893349-aa59d680-5bea-11e9-96f4-7d350439df76.png">

## Expected Behavior
The annotation `// @Param application_profile body string true "Profile of application to be registered"`  should generate swagger spec as below, with `schema` attribute added
```
                "parameters": [
                    {
                        "in": "body",
                        "name": "application_profile",
                        "description": "Profile of application to be registered",
                        "required": true,
                        "schema": {
                            "type": "string"
                        },
                        "type": "string"
                    },
```
Then the SwaggerUI could make the parameter available for input. Please refer to `correct.png` as the expectation
<img width="1422" alt="correct" src="https://user-images.githubusercontent.com/5110431/55893632-44ba1a00-5beb-11e9-879d-0b65f225d3cd.png">

## Fix Details
The fix update the `setParamType` method in `g_docs.go`. When the target `swagger.Parameter` is of basic type, the added logic will check whether it is in body location and added `swagger.Schema` instance if it is true.

@astaxie  Would you please review this fix ? 

Thanks a lot !
