### PR TITLE
解决 go mod 下无法正常安装 bee 的问题

### DIFF
--- a/cmd/commands/dlv/dlv_amd64.go
+++ b/cmd/commands/dlv/dlv_amd64.go
@@ -28,10 +28,10 @@ import (
 	"github.com/beego/bee/cmd/commands/version"
 	beeLogger "github.com/beego/bee/logger"
 	"github.com/beego/bee/utils"
-	"github.com/derekparker/delve/pkg/terminal"
-	"github.com/derekparker/delve/service"
-	"github.com/derekparker/delve/service/rpc2"
-	"github.com/derekparker/delve/service/rpccommon"
+	"github.com/go-delve/delve/pkg/terminal"
+	"github.com/go-delve/delve/service"
+	"github.com/go-delve/delve/service/rpc2"
+	"github.com/go-delve/delve/service/rpccommon"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -43,7 +43,7 @@ var cmdDlv = &commands.Command{
 
   To debug your application using Delve, use: {{"$ bee dlv" | bold}}
 
-  For more information on Delve: https://github.com/derekparker/delve
+  For more information on Delve: https://github.com/go-delve/delve
 `,
 	PreRun: func(cmd *commands.Command, args []string) { version.ShowShortVersionBanner() },
 	Run:    runDlv,

--- a/cmd/commands/version/version.go
+++ b/cmd/commands/version/version.go
@@ -57,7 +57,7 @@ Prints the current Bee, Beego and Go version alongside the platform information.
 }
 var outputFormat string
 
-const version = "1.10.0"
+const version = "1.11.0"
 
 func init() {
 	fs := flag.NewFlagSet("version", flag.ContinueOnError)

--- a/cmd/commands/version/version.go
+++ b/cmd/commands/version/version.go
@@ -57,7 +57,7 @@ Prints the current Bee, Beego and Go version alongside the platform information.
 }
 var outputFormat string
 
-const version = "1.11.0"
+const version = "1.12.0"
 
 func init() {
 	fs := flag.NewFlagSet("version", flag.ContinueOnError)

--- a/vendor/github.com/derekparker/delve/pkg/dwarf/frame/parser.go
+++ b/vendor/github.com/derekparker/delve/pkg/dwarf/frame/parser.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/derekparker/delve/pkg/dwarf/util"
+	"github.com/go-delve/delve/pkg/dwarf/util"
 )
 
 type parsefunc func(*parseContext) parsefunc

--- a/vendor/github.com/derekparker/delve/pkg/dwarf/frame/table.go
+++ b/vendor/github.com/derekparker/delve/pkg/dwarf/frame/table.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/derekparker/delve/pkg/dwarf/util"
+	"github.com/go-delve/delve/pkg/dwarf/util"
 )
 
 type DWRule struct {

--- a/vendor/github.com/derekparker/delve/pkg/dwarf/godwarf/type.go
+++ b/vendor/github.com/derekparker/delve/pkg/dwarf/godwarf/type.go
@@ -16,8 +16,8 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/derekparker/delve/pkg/dwarf/op"
-	"github.com/derekparker/delve/pkg/dwarf/util"
+	"github.com/go-delve/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/util"
 )
 
 const (

--- a/vendor/github.com/derekparker/delve/pkg/dwarf/line/line_parser.go
+++ b/vendor/github.com/derekparker/delve/pkg/dwarf/line/line_parser.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"path/filepath"
 
-	"github.com/derekparker/delve/pkg/dwarf/util"
+	"github.com/go-delve/delve/pkg/dwarf/util"
 )
 
 type DebugLinePrologue struct {

--- a/vendor/github.com/derekparker/delve/pkg/dwarf/line/state_machine.go
+++ b/vendor/github.com/derekparker/delve/pkg/dwarf/line/state_machine.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/derekparker/delve/pkg/dwarf/util"
+	"github.com/go-delve/delve/pkg/dwarf/util"
 )
 
 type Location struct {

--- a/vendor/github.com/derekparker/delve/pkg/dwarf/op/op.go
+++ b/vendor/github.com/derekparker/delve/pkg/dwarf/op/op.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/derekparker/delve/pkg/dwarf/util"
+	"github.com/go-delve/delve/pkg/dwarf/util"
 )
 
 type Opcode byte

--- a/vendor/github.com/derekparker/delve/pkg/dwarf/reader/reader.go
+++ b/vendor/github.com/derekparker/delve/pkg/dwarf/reader/reader.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/derekparker/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/op"
 )
 
 type Reader struct {

--- a/vendor/github.com/derekparker/delve/pkg/proc/arch.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/arch.go
@@ -3,8 +3,8 @@ package proc
 import (
 	"encoding/binary"
 
-	"github.com/derekparker/delve/pkg/dwarf/frame"
-	"github.com/derekparker/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/frame"
+	"github.com/go-delve/delve/pkg/dwarf/op"
 	"golang.org/x/arch/x86/x86asm"
 )
 

--- a/vendor/github.com/derekparker/delve/pkg/proc/bininfo.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/bininfo.go
@@ -17,12 +17,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/derekparker/delve/pkg/dwarf/frame"
-	"github.com/derekparker/delve/pkg/dwarf/godwarf"
-	"github.com/derekparker/delve/pkg/dwarf/line"
-	"github.com/derekparker/delve/pkg/dwarf/op"
-	"github.com/derekparker/delve/pkg/dwarf/reader"
-	"github.com/derekparker/delve/pkg/goversion"
+	"github.com/go-delve/delve/pkg/dwarf/frame"
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/dwarf/line"
+	"github.com/go-delve/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/reader"
+	"github.com/go-delve/delve/pkg/goversion"
 )
 
 // BinaryInfo holds information on the binary being executed.

--- a/vendor/github.com/derekparker/delve/pkg/proc/core/core.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/core/core.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // A SplicedMemory represents a memory space formed from multiple regions,

--- a/vendor/github.com/derekparker/delve/pkg/proc/core/linux_amd64_core.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/core/linux_amd64_core.go
@@ -10,8 +10,8 @@ import (
 
 	"golang.org/x/arch/x86/x86asm"
 
-	"github.com/derekparker/delve/pkg/proc"
-	"github.com/derekparker/delve/pkg/proc/linutil"
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc/linutil"
 )
 
 // Copied from golang.org/x/sys/unix.PtraceRegs since it's not available on

--- a/vendor/github.com/derekparker/delve/pkg/proc/eval.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/eval.go
@@ -14,9 +14,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/derekparker/delve/pkg/dwarf/godwarf"
-	"github.com/derekparker/delve/pkg/dwarf/reader"
-	"github.com/derekparker/delve/pkg/goversion"
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/dwarf/reader"
+	"github.com/go-delve/delve/pkg/goversion"
 )
 
 var errOperationOnSpecialFloat = errors.New("operations on non-finite floats not implemented")

--- a/vendor/github.com/derekparker/delve/pkg/proc/fncall.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/fncall.go
@@ -11,10 +11,10 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/derekparker/delve/pkg/dwarf/godwarf"
-	"github.com/derekparker/delve/pkg/dwarf/op"
-	"github.com/derekparker/delve/pkg/dwarf/reader"
-	"github.com/derekparker/delve/pkg/logflags"
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/reader"
+	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/arch/x86/x86asm"
 )

--- a/vendor/github.com/derekparker/delve/pkg/proc/gdbserial/gdbserver.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/gdbserial/gdbserver.go
@@ -80,9 +80,9 @@ import (
 
 	"golang.org/x/arch/x86/x86asm"
 
-	"github.com/derekparker/delve/pkg/logflags"
-	"github.com/derekparker/delve/pkg/proc"
-	"github.com/derekparker/delve/pkg/proc/linutil"
+	"github.com/go-delve/delve/pkg/logflags"
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc/linutil"
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 )

--- a/vendor/github.com/derekparker/delve/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/gdbserial/gdbserver_conn.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/derekparker/delve/pkg/logflags"
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/logflags"
+	"github.com/go-delve/delve/pkg/proc"
 	"github.com/sirupsen/logrus"
 )
 

--- a/vendor/github.com/derekparker/delve/pkg/proc/mem.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/mem.go
@@ -3,7 +3,7 @@ package proc
 import (
 	"errors"
 
-	"github.com/derekparker/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/op"
 )
 
 const cacheEnabled = true

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/nonative_darwin.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/nonative_darwin.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 var ErrNativeBackendDisabled = errors.New("native backend disabled during compilation")

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/proc.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/proc.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // Process represents all of the information the debugger

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/proc_darwin.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/proc_darwin.go
@@ -18,7 +18,7 @@ import (
 
 	sys "golang.org/x/sys/unix"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // OSProcessDetails holds Darwin specific information.

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/proc_linux.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/proc_linux.go
@@ -18,8 +18,8 @@ import (
 
 	sys "golang.org/x/sys/unix"
 
-	"github.com/derekparker/delve/pkg/proc"
-	"github.com/derekparker/delve/pkg/proc/linutil"
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc/linutil"
 	"github.com/mattn/go-isatty"
 )
 
@@ -31,7 +31,7 @@ const (
 	StatusZombie    = 'Z'
 
 	// Kernel 2.6 has TraceStop as T
-	// TODO(derekparker) Since this means something different based on the
+	// TODO(go-delve) Since this means something different based on the
 	// version of the kernel ('T' is job control stop on modern 3.x+ kernels) we
 	// may want to differentiate at some point.
 	StatusTraceStopT = 'T'

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/proc_windows.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/proc_windows.go
@@ -13,7 +13,7 @@ import (
 
 	sys "golang.org/x/sys/windows"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // OSProcessDetails holds Windows specific information.

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/ptrace_linux.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/ptrace_linux.go
@@ -6,7 +6,7 @@ import (
 
 	sys "golang.org/x/sys/unix"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // PtraceAttach executes the sys.PtraceAttach call.
@@ -69,7 +69,7 @@ func PtraceGetRegset(tid int) (regset proc.LinuxX86Xstate, err error) {
 	_, _, err = syscall.Syscall6(syscall.SYS_PTRACE, sys.PTRACE_GETREGSET, uintptr(tid), _NT_X86_XSTATE, uintptr(unsafe.Pointer(&iov)), 0, 0)
 	if err != syscall.Errno(0) {
 		if err == syscall.ENODEV {
-			// ignore ENODEV, it just means this CPU or kernel doesn't support XSTATE, see https://github.com/derekparker/delve/issues/1022
+			// ignore ENODEV, it just means this CPU or kernel doesn't support XSTATE, see https://github.com/go-delve/delve/issues/1022
 			err = nil
 		}
 		return

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/registers_darwin_amd64.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/registers_darwin_amd64.go
@@ -12,7 +12,7 @@ import (
 
 	"golang.org/x/arch/x86/x86asm"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // Regs represents CPU registers on an AMD64 processor.

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/registers_linux_amd64.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/registers_linux_amd64.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/arch/x86/x86asm"
 	sys "golang.org/x/sys/unix"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // Regs is a wrapper for sys.PtraceRegs.

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/registers_windows_amd64.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/registers_windows_amd64.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/arch/x86/x86asm"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // Regs represents CPU registers on an AMD64 processor.

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/threads.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/threads.go
@@ -3,7 +3,7 @@ package native
 import (
 	"fmt"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // Thread represents a single thread in the traced process

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/threads_darwin.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/threads_darwin.go
@@ -12,7 +12,7 @@ import (
 
 	sys "golang.org/x/sys/unix"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // WaitStatus is a synonym for the platform-specific WaitStatus

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/threads_linux.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/threads_linux.go
@@ -7,7 +7,7 @@ import (
 
 	sys "golang.org/x/sys/unix"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 type WaitStatus sys.WaitStatus

--- a/vendor/github.com/derekparker/delve/pkg/proc/native/threads_windows.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/native/threads_windows.go
@@ -6,7 +6,7 @@ import (
 
 	sys "golang.org/x/sys/windows"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // WaitStatus is a synonym for the platform-specific WaitStatus

--- a/vendor/github.com/derekparker/delve/pkg/proc/proc.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/proc.go
@@ -69,7 +69,7 @@ func (err *ErrFunctionNotFound) Error() string {
 // If lineOffset is passed FindFunctionLocation will return the address of that line
 // Pass lineOffset == 0 and firstLine == false if you want the address for the function's entry point
 // Note that setting breakpoints at that address will cause surprising behavior:
-// https://github.com/derekparker/delve/issues/170
+// https://github.com/go-delve/delve/issues/170
 func FindFunctionLocation(p Process, funcName string, firstLine bool, lineOffset int) (uint64, error) {
 	bi := p.BinInfo()
 	origfn := bi.LookupFunc[funcName]

--- a/vendor/github.com/derekparker/delve/pkg/proc/stack.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/stack.go
@@ -7,9 +7,9 @@ import (
 	"go/constant"
 	"strings"
 
-	"github.com/derekparker/delve/pkg/dwarf/frame"
-	"github.com/derekparker/delve/pkg/dwarf/op"
-	"github.com/derekparker/delve/pkg/dwarf/reader"
+	"github.com/go-delve/delve/pkg/dwarf/frame"
+	"github.com/go-delve/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/reader"
 )
 
 // This code is partly adapted from runtime.gentraceback in

--- a/vendor/github.com/derekparker/delve/pkg/proc/threads.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/threads.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/derekparker/delve/pkg/dwarf/godwarf"
-	"github.com/derekparker/delve/pkg/dwarf/reader"
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/dwarf/reader"
 )
 
 // Thread represents a thread.

--- a/vendor/github.com/derekparker/delve/pkg/proc/types.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/types.go
@@ -18,12 +18,12 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/derekparker/delve/pkg/dwarf/godwarf"
-	"github.com/derekparker/delve/pkg/dwarf/line"
-	"github.com/derekparker/delve/pkg/dwarf/op"
-	"github.com/derekparker/delve/pkg/dwarf/reader"
-	"github.com/derekparker/delve/pkg/goversion"
-	"github.com/derekparker/delve/pkg/logflags"
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/dwarf/line"
+	"github.com/go-delve/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/reader"
+	"github.com/go-delve/delve/pkg/goversion"
+	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/sirupsen/logrus"
 )
 

--- a/vendor/github.com/derekparker/delve/pkg/proc/variables.go
+++ b/vendor/github.com/derekparker/delve/pkg/proc/variables.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/derekparker/delve/pkg/dwarf/godwarf"
-	"github.com/derekparker/delve/pkg/dwarf/op"
-	"github.com/derekparker/delve/pkg/dwarf/reader"
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/reader"
 )
 
 const (

--- a/vendor/github.com/derekparker/delve/pkg/terminal/command.go
+++ b/vendor/github.com/derekparker/delve/pkg/terminal/command.go
@@ -20,9 +20,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/cosiner/argv"
-	"github.com/derekparker/delve/service"
-	"github.com/derekparker/delve/service/api"
-	"github.com/derekparker/delve/service/debugger"
+	"github.com/go-delve/delve/service"
+	"github.com/go-delve/delve/service/api"
+	"github.com/go-delve/delve/service/debugger"
 )
 
 const optimizedFunctionWarning = "Warning: debugging optimized function"
@@ -113,14 +113,14 @@ Type "help" followed by the name of a command for more information about it.`},
 
 	break [name] <linespec>
 
-See $GOPATH/src/github.com/derekparker/delve/Documentation/cli/locspec.md for the syntax of linespec.
+See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/locspec.md for the syntax of linespec.
 
 See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"trace", "t"}, cmdFn: tracepoint, helpMsg: `Set tracepoint.
 
 	trace [name] <linespec>
 
-A tracepoint is a breakpoint that does not stop the execution of the program, instead when the tracepoint is hit a notification is displayed. See $GOPATH/src/github.com/derekparker/delve/Documentation/cli/locspec.md for the syntax of linespec.
+A tracepoint is a breakpoint that does not stop the execution of the program, instead when the tracepoint is hit a notification is displayed. See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/locspec.md for the syntax of linespec.
 
 See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"restart", "r"}, cmdFn: restart, helpMsg: `Restart process.
@@ -190,7 +190,7 @@ Called with more arguments it will execute a command on the specified goroutine.
 
 	[goroutine <n>] [frame <m>] print <expression>
 
-See $GOPATH/src/github.com/derekparker/delve/Documentation/cli/expr.md for a description of supported expressions.`},
+See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/expr.md for a description of supported expressions.`},
 		{aliases: []string{"whatis"}, cmdFn: whatisCommand, helpMsg: `Prints type of an expression.
 
 	whatis <expression>`},
@@ -198,7 +198,7 @@ See $GOPATH/src/github.com/derekparker/delve/Documentation/cli/expr.md for a des
 
 	[goroutine <n>] [frame <m>] set <variable> = <value>
 
-See $GOPATH/src/github.com/derekparker/delve/Documentation/cli/expr.md for a description of supported expressions. Only numerical variables and pointers can be changed.`},
+See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/expr.md for a description of supported expressions. Only numerical variables and pointers can be changed.`},
 		{aliases: []string{"sources"}, cmdFn: sources, helpMsg: `Print list of source files.
 
 	sources [<regex>]

--- a/vendor/github.com/derekparker/delve/pkg/terminal/config.go
+++ b/vendor/github.com/derekparker/delve/pkg/terminal/config.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/derekparker/delve/pkg/config"
+	"github.com/go-delve/delve/pkg/config"
 )
 
 func configureCmd(t *Term, ctx callContext, args string) error {

--- a/vendor/github.com/derekparker/delve/pkg/terminal/disasmprint.go
+++ b/vendor/github.com/derekparker/delve/pkg/terminal/disasmprint.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
-	"github.com/derekparker/delve/service/api"
+	"github.com/go-delve/delve/service/api"
 )
 
 func DisasmPrint(dv api.AsmInstructions, out io.Writer) {

--- a/vendor/github.com/derekparker/delve/pkg/terminal/docgen.go
+++ b/vendor/github.com/derekparker/delve/pkg/terminal/docgen.go
@@ -7,7 +7,7 @@ import (
 )
 
 func replaceDocPath(s string) string {
-	const docpath = "$GOPATH/src/github.com/derekparker/delve/"
+	const docpath = "$GOPATH/src/github.com/go-delve/delve/"
 
 	for {
 		start := strings.Index(s, docpath)
@@ -22,7 +22,7 @@ func replaceDocPath(s string) string {
 		}
 
 		text := s[start+len(docpath) : end]
-		s = s[:start] + fmt.Sprintf("[%s](//github.com/derekparker/delve/tree/master/%s)", text, text) + s[end:]
+		s = s[:start] + fmt.Sprintf("[%s](//github.com/go-delve/delve/tree/master/%s)", text, text) + s[end:]
 	}
 }
 

--- a/vendor/github.com/derekparker/delve/pkg/terminal/terminal.go
+++ b/vendor/github.com/derekparker/delve/pkg/terminal/terminal.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/peterh/liner"
 
-	"github.com/derekparker/delve/pkg/config"
-	"github.com/derekparker/delve/service"
-	"github.com/derekparker/delve/service/api"
+	"github.com/go-delve/delve/pkg/config"
+	"github.com/go-delve/delve/service"
+	"github.com/go-delve/delve/service/api"
 )
 
 const (

--- a/vendor/github.com/derekparker/delve/service/api/conversions.go
+++ b/vendor/github.com/derekparker/delve/service/api/conversions.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/derekparker/delve/pkg/dwarf/godwarf"
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // ConvertBreakpoint converts from a proc.Breakpoint to

--- a/vendor/github.com/derekparker/delve/service/api/types.go
+++ b/vendor/github.com/derekparker/delve/service/api/types.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"unicode"
 
-	"github.com/derekparker/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc"
 )
 
 // ErrNotExecutable is an error returned when trying

--- a/vendor/github.com/derekparker/delve/service/client.go
+++ b/vendor/github.com/derekparker/delve/service/client.go
@@ -3,7 +3,7 @@ package service
 import (
 	"time"
 
-	"github.com/derekparker/delve/service/api"
+	"github.com/go-delve/delve/service/api"
 )
 
 // Client represents a debugger service client. All client methods are

--- a/vendor/github.com/derekparker/delve/service/debugger/debugger.go
+++ b/vendor/github.com/derekparker/delve/service/debugger/debugger.go
@@ -13,13 +13,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/derekparker/delve/pkg/goversion"
-	"github.com/derekparker/delve/pkg/logflags"
-	"github.com/derekparker/delve/pkg/proc"
-	"github.com/derekparker/delve/pkg/proc/core"
-	"github.com/derekparker/delve/pkg/proc/gdbserial"
-	"github.com/derekparker/delve/pkg/proc/native"
-	"github.com/derekparker/delve/service/api"
+	"github.com/go-delve/delve/pkg/goversion"
+	"github.com/go-delve/delve/pkg/logflags"
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc/core"
+	"github.com/go-delve/delve/pkg/proc/gdbserial"
+	"github.com/go-delve/delve/pkg/proc/native"
+	"github.com/go-delve/delve/service/api"
 	"github.com/sirupsen/logrus"
 )
 

--- a/vendor/github.com/derekparker/delve/service/debugger/locations.go
+++ b/vendor/github.com/derekparker/delve/service/debugger/locations.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/derekparker/delve/pkg/proc"
-	"github.com/derekparker/delve/service/api"
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/service/api"
 )
 
 const maxFindLocationCandidates = 5

--- a/vendor/github.com/derekparker/delve/service/rpc1/client.go
+++ b/vendor/github.com/derekparker/delve/service/rpc1/client.go
@@ -9,7 +9,7 @@ import (
 
 	"sync"
 
-	"github.com/derekparker/delve/service/api"
+	"github.com/go-delve/delve/service/api"
 )
 
 // Client is a RPC service.Client.

--- a/vendor/github.com/derekparker/delve/service/rpc1/server.go
+++ b/vendor/github.com/derekparker/delve/service/rpc1/server.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/derekparker/delve/pkg/proc"
-	"github.com/derekparker/delve/service"
-	"github.com/derekparker/delve/service/api"
-	"github.com/derekparker/delve/service/debugger"
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/service"
+	"github.com/go-delve/delve/service/api"
+	"github.com/go-delve/delve/service/debugger"
 )
 
 var defaultLoadConfig = proc.LoadConfig{true, 1, 64, 64, -1}

--- a/vendor/github.com/derekparker/delve/service/rpc2/client.go
+++ b/vendor/github.com/derekparker/delve/service/rpc2/client.go
@@ -8,8 +8,8 @@ import (
 	"net/rpc/jsonrpc"
 	"time"
 
-	"github.com/derekparker/delve/service"
-	"github.com/derekparker/delve/service/api"
+	"github.com/go-delve/delve/service"
+	"github.com/go-delve/delve/service/api"
 )
 
 // Client is a RPC service.Client.

--- a/vendor/github.com/derekparker/delve/service/rpc2/server.go
+++ b/vendor/github.com/derekparker/delve/service/rpc2/server.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/derekparker/delve/service"
-	"github.com/derekparker/delve/service/api"
-	"github.com/derekparker/delve/service/debugger"
+	"github.com/go-delve/delve/service"
+	"github.com/go-delve/delve/service/api"
+	"github.com/go-delve/delve/service/debugger"
 )
 
 type RPCServer struct {
@@ -423,7 +423,7 @@ type EvalOut struct {
 
 // EvalVariable returns a variable in the specified context.
 //
-// See https://github.com/derekparker/delve/wiki/Expressions for
+// See https://github.com/go-delve/delve/wiki/Expressions for
 // a description of acceptable values of arg.Expr.
 func (s *RPCServer) Eval(arg EvalIn, out *EvalOut) error {
 	cfg := arg.Cfg

--- a/vendor/github.com/derekparker/delve/service/rpccommon/server.go
+++ b/vendor/github.com/derekparker/delve/service/rpccommon/server.go
@@ -16,13 +16,13 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/derekparker/delve/pkg/logflags"
-	"github.com/derekparker/delve/pkg/version"
-	"github.com/derekparker/delve/service"
-	"github.com/derekparker/delve/service/api"
-	"github.com/derekparker/delve/service/debugger"
-	"github.com/derekparker/delve/service/rpc1"
-	"github.com/derekparker/delve/service/rpc2"
+	"github.com/go-delve/delve/pkg/logflags"
+	"github.com/go-delve/delve/pkg/version"
+	"github.com/go-delve/delve/service"
+	"github.com/go-delve/delve/service/api"
+	"github.com/go-delve/delve/service/debugger"
+	"github.com/go-delve/delve/service/rpc1"
+	"github.com/go-delve/delve/service/rpc2"
 	"github.com/sirupsen/logrus"
 )
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -16,140 +16,140 @@
 		},
 		{
 			"checksumSHA1": "71Ih+BWcUNqZZcKKWcCmDRTZBFw=",
-			"origin": "github.com/derekparker/delve/vendor/github.com/cosiner/argv",
+			"origin": "github.com/go-delve/delve/vendor/github.com/cosiner/argv",
 			"path": "github.com/cosiner/argv",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "v+Q3iYeRP3r9ajsW0J2PxGWdlwA=",
-			"path": "github.com/derekparker/delve/pkg/config",
+			"path": "github.com/go-delve/delve/pkg/config",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "GhNaVSsHXTmTHd7julSi5xtZD2w=",
-			"path": "github.com/derekparker/delve/pkg/dwarf/frame",
+			"path": "github.com/go-delve/delve/pkg/dwarf/frame",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "VCDMk/5/pkVOQCBcATdCixGpk3s=",
-			"path": "github.com/derekparker/delve/pkg/dwarf/godwarf",
+			"path": "github.com/go-delve/delve/pkg/dwarf/godwarf",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "cJJirrDqATjg6/XbPrG7KCIsP9E=",
-			"path": "github.com/derekparker/delve/pkg/dwarf/line",
+			"path": "github.com/go-delve/delve/pkg/dwarf/line",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "7GMg+SBj0vNTzYFm5rTQkbQGhTQ=",
-			"path": "github.com/derekparker/delve/pkg/dwarf/op",
+			"path": "github.com/go-delve/delve/pkg/dwarf/op",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "RVPaMaM17/ijwKLWT1BXnF7/VQQ=",
-			"path": "github.com/derekparker/delve/pkg/dwarf/reader",
+			"path": "github.com/go-delve/delve/pkg/dwarf/reader",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "j+wqqyt6QT2RI+Ini8exsY+pIFY=",
-			"path": "github.com/derekparker/delve/pkg/dwarf/util",
+			"path": "github.com/go-delve/delve/pkg/dwarf/util",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "Zx84VNxBFf9BnN9CnrQ/StvY16I=",
-			"path": "github.com/derekparker/delve/pkg/goversion",
+			"path": "github.com/go-delve/delve/pkg/goversion",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "OYBYJW2zF7M6xisSTsn6buWAgpY=",
-			"path": "github.com/derekparker/delve/pkg/logflags",
+			"path": "github.com/go-delve/delve/pkg/logflags",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "d0BcJ+psIqmd7f6A+V6GGjNMKU8=",
-			"path": "github.com/derekparker/delve/pkg/proc",
+			"path": "github.com/go-delve/delve/pkg/proc",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "7kXN1G9KbRIs3lAH9OazJ9ZKfoY=",
-			"path": "github.com/derekparker/delve/pkg/proc/core",
+			"path": "github.com/go-delve/delve/pkg/proc/core",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "Oyb/UKf3dHNT6InxkYpqMRN8mAI=",
-			"path": "github.com/derekparker/delve/pkg/proc/gdbserial",
+			"path": "github.com/go-delve/delve/pkg/proc/gdbserial",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "mHDcnJ0Rons7meAq9DWuBCZbW7E=",
-			"path": "github.com/derekparker/delve/pkg/proc/linutil",
+			"path": "github.com/go-delve/delve/pkg/proc/linutil",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "HzvEoJxB+b7b+gl2iwWn2QTSx2k=",
-			"path": "github.com/derekparker/delve/pkg/proc/native",
+			"path": "github.com/go-delve/delve/pkg/proc/native",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "eUso2+RCuyy5y8w7xomMZa+PLLs=",
-			"path": "github.com/derekparker/delve/pkg/terminal",
+			"path": "github.com/go-delve/delve/pkg/terminal",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "njXG5km7KDV7IVuZReheCSRfXSQ=",
-			"path": "github.com/derekparker/delve/pkg/version",
+			"path": "github.com/go-delve/delve/pkg/version",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "U39K0wH1Vnkw4LVOoinqIwX8yPY=",
-			"path": "github.com/derekparker/delve/service",
+			"path": "github.com/go-delve/delve/service",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "9UZsK1xmwZ3AKrY4zzuYaIgVQgQ=",
-			"path": "github.com/derekparker/delve/service/api",
+			"path": "github.com/go-delve/delve/service/api",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "VlivUa2TLlBe6p1/YVRi3u/Lzv8=",
-			"path": "github.com/derekparker/delve/service/debugger",
+			"path": "github.com/go-delve/delve/service/debugger",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "EgqZMArkM5kmJ+QuLj/N/jqSRWU=",
-			"path": "github.com/derekparker/delve/service/rpc1",
+			"path": "github.com/go-delve/delve/service/rpc1",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "+2fLw0nSU41hfy6ISGZ47B3+N1s=",
-			"path": "github.com/derekparker/delve/service/rpc2",
+			"path": "github.com/go-delve/delve/service/rpc2",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "0Sw6L7LHcIE6VG7IpAZG8MhnICY=",
-			"path": "github.com/derekparker/delve/service/rpccommon",
+			"path": "github.com/go-delve/delve/service/rpccommon",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
@@ -185,42 +185,42 @@
 		},
 		{
 			"checksumSHA1": "+FYEqyNlPCPeFXxg7VUFp8LG108=",
-			"origin": "github.com/derekparker/delve/vendor/github.com/mattn/go-colorable",
+			"origin": "github.com/go-delve/delve/vendor/github.com/mattn/go-colorable",
 			"path": "github.com/mattn/go-colorable",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "lfn20o8UQyaq8aWKQU98qRMJlVA=",
-			"origin": "github.com/derekparker/delve/vendor/github.com/mattn/go-isatty",
+			"origin": "github.com/go-delve/delve/vendor/github.com/mattn/go-isatty",
 			"path": "github.com/mattn/go-isatty",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "ph3cNYbXMV3WTwgJz6IrmgyCFkM=",
-			"origin": "github.com/derekparker/delve/vendor/github.com/peterh/liner",
+			"origin": "github.com/go-delve/delve/vendor/github.com/peterh/liner",
 			"path": "github.com/peterh/liner",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "HSvSst2y+SkMz+BoQCxBwlWTi/w=",
-			"origin": "github.com/derekparker/delve/vendor/github.com/sirupsen/logrus",
+			"origin": "github.com/go-delve/delve/vendor/github.com/sirupsen/logrus",
 			"path": "github.com/sirupsen/logrus",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "T3ucRoHVYE7IKEjd0AvA59wUUg4=",
-			"origin": "github.com/derekparker/delve/vendor/golang.org/x/arch/x86/x86asm",
+			"origin": "github.com/go-delve/delve/vendor/golang.org/x/arch/x86/x86asm",
 			"path": "golang.org/x/arch/x86/x86asm",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"
 		},
 		{
 			"checksumSHA1": "BGm8lKZmvJbf/YOJLeL1rw2WVjA=",
-			"origin": "github.com/derekparker/delve/vendor/golang.org/x/crypto/ssh/terminal",
+			"origin": "github.com/go-delve/delve/vendor/golang.org/x/crypto/ssh/terminal",
 			"path": "golang.org/x/crypto/ssh/terminal",
 			"revision": "74c98bc9616ad4ee324eb4d31717b61f4a6ab8ce",
 			"revisionTime": "2018-05-29T15:01:51Z"


### PR DESCRIPTION
derekparker全局替换成go-delve 增加版本号v1.12.0 （建议增加新的节点，go mod 默认下载的节点还是v1.10.0 这个节点太老了）
github.com/derekparker/delve 迁移到了 github.com/go-delve/delve 此更改可解决在go mod 内无法正常安装 bee 的问题