### PR TITLE
分页查询需要返回总的数据条数

### DIFF
--- a/generate/g_model.go
+++ b/generate/g_model.go
@@ -224,11 +224,11 @@ func GetAll{{modelName}}(query map[string]string, fields []string, sortby []stri
 		}
 	}
 	
-	m := make(map[string]interface{})
+	result := make(map[string]interface{})
 	if i, ex := qs.Count(); ex != nil {
 		return nil, errors.New("Error: get total record failed")
 	} else {
-		m["TotalRecord"] = i
+		result["TotalRecord"] = i
 	}
 
 	var l []{{modelName}}
@@ -250,8 +250,8 @@ func GetAll{{modelName}}(query map[string]string, fields []string, sortby []stri
 				list = append(list, m)
 			}
 		}
-		m["List"] = list
-		return m, nil
+		result["List"] = list
+		return result, nil
 	}else {
 		return nil, err
 	}

--- a/generate/g_model.go
+++ b/generate/g_model.go
@@ -232,9 +232,9 @@ func GetAll{{modelName}}(query map[string]string, fields []string, sortby []stri
 	}
 
 	var l []{{modelName}}
-	var list []interface{}
 	qs = qs.OrderBy(sortFields...).RelatedSel()
 	if _, err = qs.Limit(limit, offset).All(&l, fields...); err == nil {
+		var list []interface{}
 		if len(fields) == 0 {
 			for _, v := range l {
 				list = append(list, v)


### PR DESCRIPTION
分页查询返回总的数据条数，以便于前端分页时显示总的页数。原来的models模板中只返回了[]interface{}