### PR TITLE
fix #648

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Bee is a command-line tool facilitating development of Beego-based application.
 To install `bee` use the `go get` command:
 
 ```bash
-go get github.com/beego/bee
+GO111MODULE=off go get github.com/beego/bee
 ```
 
 Then you can add `bee` binary to PATH environment variable in your `~/.bashrc` or `~/.bash_profile` file:
@@ -28,7 +28,7 @@ export PATH=$PATH:<your_main_gopath>/bin
 > If you already have `bee` installed, updating `bee` is simple:
 
 ```bash
-go get -u github.com/beego/bee
+GO111MODULE=off go get -u github.com/beego/bee
 ```
 
 ## Basic commands


### PR DESCRIPTION
Background: https://github.com/go-delve/delve/issues/1505

The reason is that Go module is on ("auto") by default on new version.