### PR TITLE
log error detail  when generate appcode

### DIFF
--- a/generate/g_appcode.go
+++ b/generate/g_appcode.go
@@ -379,7 +379,7 @@ func (*MysqlDB) GetConstraints(db *sql.DB, table *Table, blackList map[string]bo
 			c.table_schema = database() AND c.table_name = ? AND u.table_schema = database() AND u.table_name = ?`,
 		table.Name, table.Name) //  u.position_in_unique_constraint,
 	if err != nil {
-		beeLogger.Log.Fatal("Could not query INFORMATION_SCHEMA for PK/UK/FK information")
+		beeLogger.Log.Fatalf("Could not query INFORMATION_SCHEMA for PK/UK/FK information: %s", err)
 	}
 	for rows.Next() {
 		var constraintTypeBytes, columnNameBytes, refTableSchemaBytes, refTableNameBytes, refColumnNameBytes, refOrdinalPosBytes []byte


### PR DESCRIPTION
从 MySQL 数据表生成代码的时候，可能由于配置错误，无法获取数据表信息，所以需要在日志中显示错误细节