### PR TITLE
Better Go modules support for swagger document generation

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -102,8 +102,8 @@ func init() {
 	astPkgs = make([]*ast.Package, 0)
 }
 
-// ParsePackagesFromDir parses packages from a given directory
-func ParsePackagesFromDir(dirpath string) {
+// parsePackagesFromDir parses packages from a given directory
+func parsePackagesFromDir(dirpath string) {
 	c := make(chan error)
 
 	go func() {
@@ -157,8 +157,14 @@ func parsePackageFromDir(path string) error {
 
 // GenerateDocs generates documentations for a given path.
 func GenerateDocs(curpath string) {
-	fset := token.NewFileSet()
+	pkgspath := curpath
+	workspace := os.Getenv("BeeWorkspace")
+	if workspace != "" {
+		pkgspath = workspace
+	}
+	parsePackagesFromDir(pkgspath)
 
+	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filepath.Join(curpath, "routers", "router.go"), nil, parser.ParseComments)
 	if err != nil {
 		beeLogger.Log.Fatalf("Error while parsing router.go: %s", err)

--- a/main.go
+++ b/main.go
@@ -21,19 +21,10 @@ import (
 	"github.com/beego/bee/cmd"
 	"github.com/beego/bee/cmd/commands"
 	"github.com/beego/bee/config"
-	"github.com/beego/bee/generate/swaggergen"
 	"github.com/beego/bee/utils"
 )
 
-var (
-	workspace = os.Getenv("BeeWorkspace")
-)
-
 func main() {
-	currentpath, _ := os.Getwd()
-	if workspace != "" {
-		currentpath = workspace
-	}
 	flag.Usage = cmd.Usage
 	flag.Parse()
 	log.SetFlags(0)
@@ -66,12 +57,6 @@ func main() {
 			}
 
 			config.LoadConfig()
-
-			// Check if current directory is inside the GOPATH,
-			// if so parse the packages inside it.
-			if cmd.IfGenerateDocs(c.Name(), args) {
-				swaggergen.ParsePackagesFromDir(currentpath)
-			}
 			os.Exit(c.Run(c, args))
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 
 			// Check if current directory is inside the GOPATH,
 			// if so parse the packages inside it.
-			if utils.IsInGOPATH(currentpath) && cmd.IfGenerateDocs(c.Name(), args) {
+			if cmd.IfGenerateDocs(c.Name(), args) {
 				swaggergen.ParsePackagesFromDir(currentpath)
 			}
 			os.Exit(c.Run(c, args))


### PR DESCRIPTION
Command `bee generate docs` does not support Go modules well. This change utilizes `go/build` to resolve package paths. It supports whatever `go build` supports automatically while reducing the code complexity.

This PR also moves swagger related codes from `main` package to `swaggergen` package, making `main` package clearer.