### PR TITLE
add json tag like `json:"xxx,string"` support

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -1185,6 +1185,10 @@ func parseStruct(st *ast.StructType, k string, m *swagger.Schema, realTypes *[]s
 						mp.Example = str2RealType(example, realType)
 					}
 
+					if len(tagValues) == 2 && tagValues[1] == "string" {
+						mp.Type = "string"
+					}
+
 					m.Properties[name] = mp
 				}
 				if ignore := stag.Get("ignore"); ignore != "" {


### PR DESCRIPTION
当结构体定义为
```golang
type XX struct {
  Id int64 `json:"id,string"`
}
```
时, 生成的 swagger 文件, 解析得到的 类型为 int64, 但是按照 json 规则, 应该为 string 类型
这次pr, 解决了这个问题
