### PR TITLE
Updated Dockerfile template (fixes beego/bee#712)

### DIFF
--- a/cmd/commands/dockerize/dockerize.go
+++ b/cmd/commands/dockerize/dockerize.go
@@ -40,7 +40,6 @@ COPY . .
 
 # Compile the binary and statically link
 RUN dep init
-# RUN dep ensure
 RUN go mod vendor
 RUN CGO_ENABLED=0 go build -ldflags '-d -w -s'
 


### PR DESCRIPTION
Updated Dockerfile template to use `dep` instead of `godep`.

Also simplified template:
- used `COPY` instead of `ADD` (preferred)
- used `$WORKDIR` instead of `$APP_DIR` (avoids cd'ing and mkdir)