### PR TITLE
Fix the path to swagger package in beego

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -35,8 +35,8 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/astaxie/beego/server/web/swagger"
-	"github.com/astaxie/beego/core/utils"
+	"github.com/astaxie/beego/swagger"
+	"github.com/astaxie/beego/utils"
 	beeLogger "github.com/beego/bee/logger"
 )
 


### PR DESCRIPTION
Update path to swagger package in the beego to address the bee install issue mentioned here
https://github.com/beego/bee/issues/732