### PR TITLE
replace github.com/gadelkareem/delve with github.com/go-delve/delve

### DIFF
--- a/cmd/commands/dlv/dlv_amd64.go
+++ b/cmd/commands/dlv/dlv_amd64.go
@@ -28,12 +28,12 @@ import (
 	"github.com/beego/bee/cmd/commands/version"
 	beeLogger "github.com/beego/bee/logger"
 	"github.com/beego/bee/utils"
+	"github.com/go-delve/delve/service"
+	"github.com/go-delve/delve/service/debugger"
+	"github.com/go-delve/delve/service/rpc2"
+	"github.com/go-delve/delve/service/rpccommon"
+	"github.com/go-delve/delve/pkg/terminal"
 	"github.com/fsnotify/fsnotify"
-	"github.com/gadelkareem/delve/pkg/terminal"
-	"github.com/gadelkareem/delve/service"
-	"github.com/gadelkareem/delve/service/debugger"
-	"github.com/gadelkareem/delve/service/rpc2"
-	"github.com/gadelkareem/delve/service/rpccommon"
 )
 
 var cmdDlv = &commands.Command{
@@ -44,7 +44,7 @@ var cmdDlv = &commands.Command{
 
   To debug your application using Delve, use: {{"$ bee dlv" | bold}}
 
-  For more information on Delve: https://github.com/gadelkareem/delve
+  For more information on Delve: https://github.com/go-delve/delve
 `,
 	PreRun: func(cmd *commands.Command, args []string) { version.ShowShortVersionBanner() },
 	Run:    runDlv,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/flosch/pongo2 v0.0.0-20200529170236-5abacdfa4915
 	github.com/fsnotify/fsnotify v1.4.9
-	github.com/gadelkareem/delve v1.4.2-0.20200619175259-dcd01330766f
+	github.com/go-delve/delve v1.5.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/lib/pq v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/glendc/gopher-json v0.0.0-20170414221815-dc4743023d0c/go.mod h1:Gja1A+xZ9BoviGJNA2E9vFkPjjsl+CoJxSXiQM1UXtw=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/go-delve/delve v1.5.0 h1:gQsRvFdR0BGk19NROQZsAv6iG4w5QIZoJlxJeEUBb0c=
+github.com/go-delve/delve v1.5.0/go.mod h1:c6b3a1Gry6x8a4LGCe/CWzrocrfaHvkUxCj3k4bvSUQ=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=


### PR DESCRIPTION
We have several issues about installing bee failed due to `delve`. I replaced `github.com/gadelkareem/delve` with `github.com/go-delve/delve` because `github.com/go-delve/delve` is more active than `github.com/gadelkareem/delve`.
And I think using the stable version makes bee more stable.