### PR TITLE
fix help message

### DIFF
--- a/cmd/bee.go
+++ b/cmd/bee.go
@@ -90,6 +90,7 @@ func Usage() {
 func Help(args []string) {
 	if len(args) == 0 {
 		Usage()
+		return
 	}
 	if len(args) != 1 {
 		utils.PrintErrorAndExit("Too many arguments", ErrorTemplate)


### PR DESCRIPTION
`bee help` show useless message.
![help_message](https://user-images.githubusercontent.com/8190833/103227721-fc680000-4969-11eb-939b-00d1f08bf189.png)
