### PR TITLE
fix required struct tag when anonymous nested struct

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -1232,6 +1232,7 @@ func parseStruct(imports []*ast.ImportSpec, st *ast.StructType, k string, m *swa
 					for name, p := range nm.Properties {
 						m.Properties[name] = p
 					}
+					m.Required = append(m.Required, nm.Required...)
 					continue
 				}
 			}


### PR DESCRIPTION
when use anonymous nested structures at @Param body，required stuct tag is invalid.
struct define like follow:
```go
type StructA struct {
   Name string `json:"name" required:"true"`
}

type StructB struct {
  StructA 
}
```

error:
when use StructB  in @Param，required struct tag is not generated in swagger.json.