### PR TITLE
fix required struct tag when anonymous nested struct

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -1224,6 +1224,7 @@ func parseStruct(st *ast.StructType, k string, m *swagger.Schema, realTypes *[]s
 					for name, p := range nm.Properties {
 						m.Properties[name] = p
 					}
+					m.Required = append(m.Required, nm.Required...)
 					continue
 				}
 			}


### PR DESCRIPTION
when use anonymous nested structures at @param body，required stuct tag is invalid.
struct define like follow:

```go
type StructA struct {
   Name string `json:"name" required:"true"`
}

type StructB struct {
  StructA 
}
```
error:
when use StructB in @param，required struct tag is not generated in swagger.json.