### PR TITLE
[Bug] Bold message should be end with all attributes off(\x1b[0m)

### DIFF
--- a/logger/colors/color.go
+++ b/logger/colors/color.go
@@ -54,7 +54,7 @@ func NewModeColorWriter(w io.Writer, mode outputMode) io.Writer {
 }
 
 func Bold(message string) string {
-	return fmt.Sprintf("\x1b[1m%s\x1b[21m", message)
+	return fmt.Sprintf("\x1b[1m%s\x1b[0m", message)
 }
 
 // Black returns a black string


### PR DESCRIPTION
Does not revert to original color after displaying bold attributed text.

# bash

##### Before

<img width="825" alt="before" src="https://user-images.githubusercontent.com/19504988/131852812-1ec99c05-9a46-43a2-8c69-30516270418d.png">

##### After
I fixed with ANSICON of all attributes off(\x1b[0m)

<img width="1094" alt="after" src="https://user-images.githubusercontent.com/19504988/131852795-71758b34-fc8d-4f24-8293-c2af9dd31bed.png">


# zsh

##### Bebore

<img width="439" alt="스크린샷 2021-09-02 오후 10 43 46" src="https://user-images.githubusercontent.com/19504988/131854574-f1d2e362-a70a-40d2-baac-f4e1725c5c7b.png">

##### After

<img width="1088" alt="스크린샷 2021-09-02 오후 10 43 53" src="https://user-images.githubusercontent.com/19504988/131854592-2caa35e3-cc2f-4616-9e74-42728711026c.png">