### PR TITLE
Fix description of the new command

### DIFF
--- a/cmd/commands/new/new.go
+++ b/cmd/commands/new/new.go
@@ -35,7 +35,7 @@ var CmdNew = &commands.Command{
 	Short:     "Creates a Beego application",
 	Long: `
 Creates a Beego application for the given app name in the current directory.
-  now default supoort generate a go modules project
+  now defaults to generating as a go modules project
   The command 'new' creates a folder named [appname] [-gopath=false] [-beego=v1.12.3] and generates the following structure:
 
             ├── main.go


### PR DESCRIPTION
Not exactly sure which way you prefer it said. However, I think it would be better to change `supoort` as it is a spelling mistake.
You could also use something like  `now defaults to supporting and generating as a go modules project`, for example.