### PR TITLE
beeLogger lib missing in import list for var apiMainconngo

### DIFF
--- a/cmd/commands/api/apiapp.go
+++ b/cmd/commands/api/apiapp.go
@@ -94,6 +94,7 @@ import (
 	_ "{{.Appname}}/routers"
 
 	beego "github.com/beego/beego/v2/server/web"
+	beeLogger "github.com/beego/bee/v2/logger"
 	"github.com/beego/beego/v2/client/orm"
 	{{.DriverPkg}}
 )


### PR DESCRIPTION
Clearly main function for var apiMainconngo uses "beeLogger.Log.Fatal("%s", err", resulting in an error when executing bee run. Issue is resolved by adding lib "beeLogger "github.com/beego/bee/v2/logger" to var apiMainconngo's import list.